### PR TITLE
feat: 🎸 add W3C-DID as supported type for issuer identityProof

### DIFF
--- a/src/schema/3.0/schema.json
+++ b/src/schema/3.0/schema.json
@@ -22,11 +22,11 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["DNS-TXT"]
+              "enum": ["DNS-TXT", "W3C-DID"]
             },
             "location": {
               "type": "string",
-              "description": "Url of the website referencing to document store"
+              "description": "Url of the website referencing to document store OR valid DID as defined by W3C: https://www.w3.org/TR/did-core/"
             }
           },
           "additionalProperties": false,

--- a/src/schema/3.0/schema.test.ts
+++ b/src/schema/3.0/schema.test.ts
@@ -473,13 +473,13 @@ describe("open-attestation/3.0", () => {
     it("should be valid when type is W3C-DID and location is a valid DID", () => {
       const document = {
         ...sampleDoc,
-        issuer: { 
-          ...sampleDoc.issuer, 
-          identityProof: { 
-            ...sampleDoc.issuer.identityProof, 
-            type: "W3C-DID", 
-            location: "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a" 
-          } 
+        issuer: {
+          ...sampleDoc.issuer,
+          identityProof: {
+            ...sampleDoc.issuer.identityProof,
+            type: "W3C-DID",
+            location: "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a"
+          }
         }
       };
       const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });

--- a/src/schema/3.0/schema.test.ts
+++ b/src/schema/3.0/schema.test.ts
@@ -462,6 +462,29 @@ describe("open-attestation/3.0", () => {
       const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
       expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
     });
+    it("should be valid when identityProof type is W3C-DID", () => {
+      const document = {
+        ...sampleDoc,
+        issuer: { ...sampleDoc.issuer, identityProof: { ...sampleDoc.issuer.identityProof, type: "W3C-DID" } }
+      };
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+    });
+    it("should be valid when type is W3C-DID and location is a valid DID", () => {
+      const document = {
+        ...sampleDoc,
+        issuer: { 
+          ...sampleDoc.issuer, 
+          identityProof: { 
+            ...sampleDoc.issuer.identityProof, 
+            type: "W3C-DID", 
+            location: "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a" 
+          } 
+        }
+      };
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+    });
     it("should be valid when id is an URI", () => {
       const document = {
         ...sampleDoc,
@@ -627,7 +650,7 @@ describe("open-attestation/3.0", () => {
         ]);
       }
     });
-    it("should be invalid if identityProof type is not DNS-TXT", () => {
+    it("should be invalid if identityProof type is not valid", () => {
       expect.assertions(2);
       const document = {
         ...sampleDoc,
@@ -643,7 +666,7 @@ describe("open-attestation/3.0", () => {
             keyword: "enum",
             dataPath: ".issuer.identityProof.type",
             schemaPath: "#/definitions/issuer/properties/identityProof/properties/type/enum",
-            params: { allowedValues: ["DNS-TXT"] },
+            params: { allowedValues: ["DNS-TXT", "W3C-DID"] },
             message: "should be equal to one of the allowed values"
           }
         ]);

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -324,6 +324,36 @@ describe("E2E Test Scenarios", () => {
         })
       ).toStrictEqual(true);
     });
+    test("should return false when document is invalid due to no W3D-DID location", () => {
+      expect(
+        validateSchema({
+          version: "open-attestation/3.0",
+          schema: "http://example.com/schemaV3.json",
+          data: {
+            reference: "reference",
+            name: "name",
+            validFrom: "2010-01-01T19:23:24Z",
+            issuer: {
+              id: "https://example.com",
+              name: "issuer.name",
+              identityProof: {
+                type: IdentityProofType.W3CDid,
+              }
+            },
+            template: {
+              name: "template.name",
+              type: "EMBEDDED_RENDERER",
+              url: "https://example.com"
+            },
+            proof: {
+              type: "OpenAttestationSignature2018",
+              method: "TOKEN_REGISTRY",
+              value: "proof.value"
+            }
+          }
+        })
+      ).toStrictEqual(false);
+    });
     test("should return true when document is valid and version is not provided", () => {
       expect(
         validateSchema({

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -145,7 +145,9 @@ describe("E2E Test Scenarios", () => {
       expect(wrappedDocumentWithW3CDID.signature.proof).toEqual([]);
       expect(wrappedDocumentWithW3CDID.signature.merkleRoot).toBe(wrappedDocumentWithW3CDID.signature.targetHash);
       expect(wrappedDocumentWithW3CDID.data.issuer.identityProof.type).toContain(IdentityProofType.W3CDid);
-      expect(wrappedDocumentWithW3CDID.data.issuer.identityProof.location).toContain(openAttestationDataWithW3CDID.issuer.identityProof.location);
+      expect(wrappedDocumentWithW3CDID.data.issuer.identityProof.location).toContain(
+        openAttestationDataWithW3CDID.issuer.identityProof.location
+      );
     });
     test("checks that document is wrapped correctly", () => {
       const verified = verifySignature(wrappedDocument);
@@ -337,7 +339,7 @@ describe("E2E Test Scenarios", () => {
               id: "https://example.com",
               name: "issuer.name",
               identityProof: {
-                type: IdentityProofType.W3CDid,
+                type: IdentityProofType.W3CDid
               }
             },
             template: {


### PR DESCRIPTION
* add `W3C-DID` as a supported identityProof type in schema 3.0
* add tests where type: `W3C-DID` and location: `did:ethr:0x...`