### PR TITLE
feat: updated schema id to url

### DIFF
--- a/src/@types/document.ts
+++ b/src/@types/document.ts
@@ -1,5 +1,10 @@
 export type SignatureProofAlgorithm = "SHA3MerkleProof";
 
+export enum SchemaId {
+  v2 = "https://schema.openattestation.com/2.0/schema.json",
+  v3 = "https://schema.openattestation.com/3.0/schema.json"
+}
+
 export interface Signature {
   type: SignatureProofAlgorithm;
   targetHash: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import Ajv from "ajv";
 import { digestDocument } from "./digest";
 import { getSchema, validateSchema as validate } from "./schema";
 import { wrap } from "./signature";
-import { SchematisedDocument, WrappedDocument } from "./@types/document";
+import { SchematisedDocument, WrappedDocument, SchemaId } from "./@types/document";
 import { saltData } from "./privacy/salt";
 import * as utils from "./utils";
 import { setData } from "./privacy";
@@ -11,9 +11,9 @@ import * as v3 from "./__generated__/schemaV3";
 
 interface WrapDocumentOption {
   externalSchemaId?: string;
-  version?: "open-attestation/2.0" | "open-attestation/3.0";
+  version?: SchemaId;
 }
-const defaultVersion = "open-attestation/2.0";
+const defaultVersion = SchemaId.v2;
 
 const createDocument = (data: any, option?: WrapDocumentOption) => {
   const documentSchema: SchematisedDocument = {
@@ -60,7 +60,7 @@ export const wrapDocuments = <T = unknown>(dataArray: T[], options?: WrapDocumen
 };
 
 export const validateSchema = (document: WrappedDocument): boolean => {
-  return validate(document, getSchema(`${document?.version || "open-attestation/2.0"}`)).length === 0;
+  return validate(document, getSchema(`${document?.version || SchemaId.v2}`)).length === 0;
 };
 
 export { digestDocument } from "./digest";

--- a/src/schema/2.0/schema.json
+++ b/src/schema/2.0/schema.json
@@ -1,6 +1,6 @@
 {
   "title": "Open Attestation Schema v2",
-  "$id": "open-attestation/2.0",
+  "$id": "https://schema.openattestation.com/2.0/schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "identityProof": {

--- a/src/schema/2.0/schema.test.ts
+++ b/src/schema/2.0/schema.test.ts
@@ -5,11 +5,12 @@ import { cloneDeep, merge, omit } from "lodash";
 import sampleToken from "./sample-token.json";
 import sampleDoc from "./sample-document.json";
 import { wrapDocument } from "../../index";
+import { SchemaId } from "../../@types/document";
 
 describe("schema/v2.0", () => {
   it("should be valid with sample document", () => {
     const wrappedDocument = wrapDocument(sampleDoc);
-    expect(wrappedDocument.version).toBe("open-attestation/2.0");
+    expect(wrappedDocument.version).toBe(SchemaId.v2);
   });
 
   it("should be invalid if identity type is other than DNS-TXT", () => {
@@ -60,7 +61,7 @@ describe("schema/v2.0", () => {
       ]
     });
     const wrappedDocument = wrapDocument(document);
-    expect(wrappedDocument.version).toBe("open-attestation/2.0");
+    expect(wrappedDocument.version).toBe(SchemaId.v2);
   });
   it("should be valid then issuer has extra properties", () => {
     const document = merge(sampleDoc, {
@@ -76,7 +77,7 @@ describe("schema/v2.0", () => {
       ]
     });
     const wrappedDocument = wrapDocument(document);
-    expect(wrappedDocument.version).toBe("open-attestation/2.0");
+    expect(wrappedDocument.version).toBe(SchemaId.v2);
   });
 
   it("should not be valid without identityProof", () => {
@@ -107,7 +108,7 @@ describe("schema/v2.0", () => {
 
   it("should be valid with sample token", () => {
     const wrappedDocument = wrapDocument(sampleToken);
-    expect(wrappedDocument.version).toBe("open-attestation/2.0");
+    expect(wrappedDocument.version).toBe(SchemaId.v2);
   });
 
   it("should not be valid with document with both documentStore and tokenRegistry", () => {
@@ -220,17 +221,17 @@ describe("schema/v2.0", () => {
 
   it("should be valid with additonal key:value", () => {
     const wrappedDocument = wrapDocument({ ...sampleDoc, foo: "bar" });
-    expect(wrappedDocument.version).toBe("open-attestation/2.0");
+    expect(wrappedDocument.version).toBe(SchemaId.v2);
   });
 
   it("should be valid without $template (will use default view)", () => {
     const wrappedDocument = wrapDocument(omit(cloneDeep(sampleDoc), "$template"));
-    expect(wrappedDocument.version).toBe("open-attestation/2.0");
+    expect(wrappedDocument.version).toBe(SchemaId.v2);
   });
 
   it("should be valid without attachments", () => {
     const wrappedDocument = wrapDocument(omit(cloneDeep(sampleDoc), "attachments"));
-    expect(wrappedDocument.version).toBe("open-attestation/2.0");
+    expect(wrappedDocument.version).toBe(SchemaId.v2);
   });
 
   it("should be invalid if $template does not have name", () => {

--- a/src/schema/3.0/schema.json
+++ b/src/schema/3.0/schema.json
@@ -1,6 +1,6 @@
 {
   "title": "Open Attestation Schema v3",
-  "$id": "open-attestation/3.0",
+  "$id": "https://schema.openattestation.com/3.0/schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
 

--- a/src/schema/3.0/schema.test.ts
+++ b/src/schema/3.0/schema.test.ts
@@ -3,41 +3,42 @@
 import { wrapDocument } from "../../index";
 import { $id } from "./schema.json";
 import sampleDoc from "./sample-document.json";
+import { SchemaId } from "../../@types/document";
 
-describe("open-attestation/3.0", () => {
+describe("schema/v3.0", () => {
   it("should be valid with sample document", () => {
-    const wrappedDocument = wrapDocument(sampleDoc, { externalSchemaId: $id, version: "open-attestation/3.0" });
-    expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+    const wrappedDocument = wrapDocument(sampleDoc, { externalSchemaId: $id, version: SchemaId.v3 });
+    expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
   });
   it("should be valid when adding any additional data", () => {
     const wrappedDocument = wrapDocument(
       { ...sampleDoc, key1: "some" },
-      { externalSchemaId: $id, version: "open-attestation/3.0" }
+      { externalSchemaId: $id, version: SchemaId.v3 }
     );
-    expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+    expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
   });
 
   describe("@context", () => {
     it("should be valid when @context is missing", () => {
       const wrappedDocument = wrapDocument(
         { ...sampleDoc, "@context": undefined },
-        { externalSchemaId: $id, version: "open-attestation/3.0" }
+        { externalSchemaId: $id, version: SchemaId.v3 }
       );
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when @context contains valid uri", () => {
       const wrappedDocument = wrapDocument(
         { ...sampleDoc, "@context": ["https://example.com"] },
-        { externalSchemaId: $id, version: "open-attestation/3.0" }
+        { externalSchemaId: $id, version: SchemaId.v3 }
       );
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
 
     it("should be invalid if @context contains one invalid uri", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, "@context": ["any"] };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -57,16 +58,16 @@ describe("open-attestation/3.0", () => {
     it("should be valid when id is missing", () => {
       const wrappedDocument = wrapDocument(
         { ...sampleDoc, id: undefined },
-        { externalSchemaId: $id, version: "open-attestation/3.0" }
+        { externalSchemaId: $id, version: SchemaId.v3 }
       );
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when @id contains valid uri", () => {
       const wrappedDocument = wrapDocument(
         { ...sampleDoc, id: "https://example.com" },
-        { externalSchemaId: $id, version: "open-attestation/3.0" }
+        { externalSchemaId: $id, version: SchemaId.v3 }
       );
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
   });
 
@@ -76,7 +77,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc };
       delete document.reference;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -94,7 +95,7 @@ describe("open-attestation/3.0", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, reference: undefined };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -112,7 +113,7 @@ describe("open-attestation/3.0", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, reference: null };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -134,7 +135,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc };
       delete document.name;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -152,7 +153,7 @@ describe("open-attestation/3.0", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, name: undefined };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -170,7 +171,7 @@ describe("open-attestation/3.0", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, name: null };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -190,9 +191,9 @@ describe("open-attestation/3.0", () => {
     it("should be valid when type is missing", () => {
       const wrappedDocument = wrapDocument(
         { ...sampleDoc, type: undefined },
-        { externalSchemaId: $id, version: "open-attestation/3.0" }
+        { externalSchemaId: $id, version: SchemaId.v3 }
       );
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
   });
 
@@ -202,7 +203,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc };
       delete document.validFrom;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -220,7 +221,7 @@ describe("open-attestation/3.0", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, validFrom: undefined };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -238,7 +239,7 @@ describe("open-attestation/3.0", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, validFrom: null };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -257,7 +258,7 @@ describe("open-attestation/3.0", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, validFrom: "some" };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -277,15 +278,15 @@ describe("open-attestation/3.0", () => {
     it("should be valid when validUntil is missing", () => {
       const wrappedDocument = wrapDocument(
         { ...sampleDoc, validUntil: undefined },
-        { externalSchemaId: $id, version: "open-attestation/3.0" }
+        { externalSchemaId: $id, version: SchemaId.v3 }
       );
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be invalid if validUntil is not a correct date", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, validUntil: "some" };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -304,25 +305,25 @@ describe("open-attestation/3.0", () => {
   describe("template", () => {
     it("should be valid when type is EMBEDDED_RENDERER", () => {
       const document = { ...sampleDoc, template: { ...sampleDoc.template, type: "EMBEDDED_RENDERER" } };
-      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when url starts with http", () => {
       const document = { ...sampleDoc, template: { ...sampleDoc.template, url: "http://some.example.com" } };
-      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when url starts with https", () => {
       const document = { ...sampleDoc, template: { ...sampleDoc.template, url: "https://some.example.com" } };
-      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
 
     it("should be invalid when adding additional data", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, template: { ...sampleDoc.template, key: "any" } };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -342,7 +343,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc };
       delete document.template;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -361,7 +362,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, template: { ...sampleDoc.template } };
       delete document.template.name;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -380,7 +381,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, template: { ...sampleDoc.template } };
       delete document.template.type;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -399,7 +400,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, template: { ...sampleDoc.template } };
       document.template.type = "SOMETHING";
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -418,7 +419,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, template: { ...sampleDoc.template } };
       delete document.template.url;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -437,7 +438,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, template: { ...sampleDoc.template } };
       document.template.url = "ftp://some";
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -459,16 +460,16 @@ describe("open-attestation/3.0", () => {
         ...sampleDoc,
         issuer: { ...sampleDoc.issuer, identityProof: { ...sampleDoc.issuer.identityProof, type: "DNS-TXT" } }
       };
-      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when identityProof type is W3C-DID", () => {
       const document = {
         ...sampleDoc,
         issuer: { ...sampleDoc.issuer, identityProof: { ...sampleDoc.issuer.identityProof, type: "W3C-DID" } }
       };
-      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when type is W3C-DID and location is a valid DID", () => {
       const document = {
@@ -482,22 +483,22 @@ describe("open-attestation/3.0", () => {
           }
         }
       };
-      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when id is an URI", () => {
       const document = {
         ...sampleDoc,
         issuer: { ...sampleDoc.issuer, id: "http://example.com" }
       };
-      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be invalid when adding additional data", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, issuer: { ...sampleDoc.issuer, key: "any" } };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -518,7 +519,7 @@ describe("open-attestation/3.0", () => {
         issuer: { ...sampleDoc.issuer, identityProof: { ...sampleDoc.issuer.identityProof, key1: "any" } }
       };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -537,7 +538,7 @@ describe("open-attestation/3.0", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, issuer: { ...sampleDoc.issuer, id: "" } };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -557,7 +558,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc };
       delete document.issuer;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -576,7 +577,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, issuer: { ...sampleDoc.issuer } };
       delete document.issuer.name;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -595,7 +596,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, issuer: { ...sampleDoc.issuer } };
       delete document.issuer.id;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -614,7 +615,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, issuer: { ...sampleDoc.issuer } };
       delete document.issuer.identityProof;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -636,7 +637,7 @@ describe("open-attestation/3.0", () => {
       };
       delete document.issuer.identityProof.type;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -658,7 +659,7 @@ describe("open-attestation/3.0", () => {
       };
       document.issuer.identityProof.type = "OTHER";
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -680,7 +681,7 @@ describe("open-attestation/3.0", () => {
       };
       delete document.issuer.identityProof.location;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -699,25 +700,25 @@ describe("open-attestation/3.0", () => {
   describe("proof", () => {
     it("should be valid when type is OpenAttestationSignature2018", () => {
       const document = { ...sampleDoc, proof: { ...sampleDoc.proof, type: "OpenAttestationSignature2018" } };
-      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when method is TOKEN_REGISTRY", () => {
       const document = { ...sampleDoc, proof: { ...sampleDoc.proof, method: "TOKEN_REGISTRY" } };
-      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when method is DOCUMENT_STORE", () => {
       const document = { ...sampleDoc, proof: { ...sampleDoc.proof, method: "DOCUMENT_STORE" } };
-      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
 
     it("should be invalid when adding additional data", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, proof: { ...sampleDoc.proof, key: "any" } };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -736,7 +737,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc };
       delete document.proof;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -755,7 +756,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, proof: { ...sampleDoc.proof } };
       delete document.proof.type;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -774,7 +775,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, proof: { ...sampleDoc.proof } };
       document.proof.type = "Something";
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -793,7 +794,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, proof: { ...sampleDoc.proof } };
       delete document.proof.method;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -812,7 +813,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, proof: { ...sampleDoc.proof } };
       document.proof.method = "Something";
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -831,7 +832,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, proof: { ...sampleDoc.proof } };
       delete document.proof.value;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -850,25 +851,25 @@ describe("open-attestation/3.0", () => {
   describe("attachments", () => {
     it("should be valid when mimeType is application/pdf", () => {
       const document = { ...sampleDoc, attachments: [{ ...sampleDoc.attachments[0], mimeType: "application/pdf" }] };
-      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when mimeType is image/png", () => {
       const document = { ...sampleDoc, attachments: [{ ...sampleDoc.attachments[0], mimeType: "image/png" }] };
-      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when mimeType is image/jpeg", () => {
       const document = { ...sampleDoc, attachments: [{ ...sampleDoc.attachments[0], mimeType: "image/jpeg" }] };
-      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
-      expect(wrappedDocument.version).toStrictEqual("open-attestation/3.0");
+      const wrappedDocument = wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
+      expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
 
     it("should be invalid when adding additional data", () => {
       expect.assertions(2);
       const document = { ...sampleDoc, attachments: [{ ...sampleDoc.attachments[0], key: "any" }] };
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -887,7 +888,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, attachments: [{ ...sampleDoc.attachments[0] }] };
       delete document.attachments[0].filename;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -906,7 +907,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, attachments: [{ ...sampleDoc.attachments[0] }] };
       delete document.attachments[0].mimeType;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -925,7 +926,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, attachments: [{ ...sampleDoc.attachments[0] }] };
       document.attachments[0].mimeType = "Something";
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -944,7 +945,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, attachments: [{ ...sampleDoc.attachments[0] }] };
       delete document.attachments[0].data;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [
@@ -963,7 +964,7 @@ describe("open-attestation/3.0", () => {
       const document = { ...sampleDoc, attachments: [{ ...sampleDoc.attachments[0] }] };
       delete document.attachments[0].type;
       try {
-        wrapDocument(document, { externalSchemaId: $id, version: "open-attestation/3.0" });
+        wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       } catch (e) {
         expect(e).toHaveProperty("message", "Invalid document");
         expect(e).toHaveProperty("validationErrors", [

--- a/src/schema/3.0/wrapped-sample-document.json
+++ b/src/schema/3.0/wrapped-sample-document.json
@@ -1,5 +1,5 @@
 {
-  "version": "open-attestation/3.0",
+  "version": "https://schema.openattestation.com/3.0/schema.json",
   "data": {
     "reference": "50152a6f-5a64-4b19-9857-ad45bd2be60f:string:SERIAL_NUMBER_123",
     "name": "e4aed1f1-928d-4664-a926-088ff975349f:string:Singapore Driving Licence",

--- a/src/schema/schema.test.ts
+++ b/src/schema/schema.test.ts
@@ -1,6 +1,6 @@
 import Ajv from "ajv";
 import { validateSchema } from "./schema";
-import { SchematisedDocument } from "../@types/document";
+import { SchematisedDocument, SchemaId } from "../@types/document";
 
 const schema = {
   $id: "http://example.com/schema.json",
@@ -36,7 +36,7 @@ describe("schema", () => {
       test("returns empty array for passing documents", () => {
         const ajv = new Ajv({ allErrors: true });
         const document: SchematisedDocument = {
-          version: "open-attestation/3.0",
+          version: SchemaId.v3,
           schema: "http://example.com/schema.json",
           data: {
             key1: 2
@@ -48,7 +48,7 @@ describe("schema", () => {
       test("returns array with errors for failing documents", () => {
         const ajv = new Ajv({ allErrors: true });
         const document: SchematisedDocument = {
-          version: "open-attestation/3.0",
+          version: SchemaId.v3,
           schema: "http://example.com/schema.json",
           data: {
             key: 2

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,6 +1,6 @@
 import * as utils from "./utils";
 import { wrapDocument } from "..";
-import { WrappedDocument } from "../@types/document";
+import { WrappedDocument, SchemaId } from "../@types/document";
 import { OpenAttestationDocument as v2OpenAttestationDocument } from "../__generated__/schemaV2";
 import {
   IdentityProofType,
@@ -203,7 +203,7 @@ describe("Util Functions", () => {
           },
           validFrom: "2010-01-01T19:23:24Z"
         },
-        { version: "open-attestation/3.0" }
+        { version: SchemaId.v3 }
       );
       expect(utils.getIssuerAddress(document)).toStrictEqual("0xabcf");
     });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,7 @@
 import { keccak256 } from "js-sha3";
 import { OpenAttestationDocument as v2OpenAttestationDocument } from "../__generated__/schemaV2";
 import { OpenAttestationDocument as v3OpenAttestationDocument } from "../__generated__/schemaV3";
-import { WrappedDocument } from "../@types/document";
+import { WrappedDocument, SchemaId } from "../@types/document";
 import { unsaltData } from "../privacy/salt";
 
 export type Hash = string | Buffer;
@@ -65,7 +65,7 @@ export function combineHashString(first?: string, second?: string): string {
 }
 
 export const isWrappedV3Document = (document: any): document is WrappedDocument<v3OpenAttestationDocument> => {
-  return document && document.version === "open-attestation/3.0";
+  return document && document.version === SchemaId.v3;
 };
 export const isWrappedV2Document = (document: any): document is WrappedDocument<v2OpenAttestationDocument> => {
   return !isWrappedV3Document(document);

--- a/test/e2e.v3.test.ts
+++ b/test/e2e.v3.test.ts
@@ -6,6 +6,7 @@ import {
   ProofType,
   TemplateType
 } from "../src/__generated__/schemaV3";
+import {SchemaId} from "../src/@types/document"
 
 const openAttestationData: OpenAttestationDocument = {
   reference: "document identifier",
@@ -82,7 +83,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("creates a wrapped document", () => {
       const wrappedDocument = wrapDocument(document, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "https://schema.openattestation.com/3.0/schema.json"
+        version: SchemaId.v3
       });
       expect(wrappedDocument.schema).toBe("http://example.com/schema.json");
       expect(wrappedDocument.data.key1).toEqual(expect.stringContaining("test"));
@@ -95,7 +96,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("creates a wrapped document with W3C-DID IdentityProof", () => {
       const wrappedDocumentWithW3CDID = wrapDocument(openAttestationDataWithW3CDID, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "https://schema.openattestation.com/3.0/schema.json"
+        version: SchemaId.v3
       });
       expect(wrappedDocumentWithW3CDID.schema).toBe("http://example.com/schema.json");
       expect(wrappedDocumentWithW3CDID.signature.type).toBe("SHA3MerkleProof");
@@ -111,7 +112,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("checks that document is wrapped correctly", () => {
       const wrappedDocument = wrapDocument(document, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "https://schema.openattestation.com/3.0/schema.json"
+        version: SchemaId.v3
       });
       const verified = verifySignature(wrappedDocument);
       expect(verified).toBe(true);
@@ -119,7 +120,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("checks that document conforms to the schema", () => {
       const wrappedDocument = wrapDocument(document, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "https://schema.openattestation.com/3.0/schema.json"
+        version: SchemaId.v3
       });
       expect(validateSchema(wrappedDocument)).toBe(true);
     });
@@ -127,7 +128,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("checks that data extracted are the same as input", () => {
       const wrappedDocument = wrapDocument(document, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "https://schema.openattestation.com/3.0/schema.json"
+        version: SchemaId.v3
       });
       const data = getData(wrappedDocument);
       expect(data).toEqual(datum[0]);
@@ -136,14 +137,14 @@ describe("v3 E2E Test Scenarios", () => {
     test("does not allow for the same merkle root to be generated", () => {
       const wrappedDocument = wrapDocument(document, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "https://schema.openattestation.com/3.0/schema.json"
+        version: SchemaId.v3
       });
-      const newDocument = wrapDocument(document, { version: "https://schema.openattestation.com/3.0/schema.json" });
+      const newDocument = wrapDocument(document, { version: SchemaId.v3 });
       expect(wrappedDocument.signature.merkleRoot).not.toBe(newDocument.signature.merkleRoot);
     });
 
     test("obfuscate data correctly", async () => {
-      const newDocument = wrapDocument(datum[2], { version: "https://schema.openattestation.com/3.0/schema.json" });
+      const newDocument = wrapDocument(datum[2], { version: SchemaId.v3 });
       const obfuscatedDocument = obfuscateDocument(newDocument, ["key2"]);
 
       const verified = verifySignature(obfuscatedDocument);
@@ -152,7 +153,7 @@ describe("v3 E2E Test Scenarios", () => {
     });
 
     test("obfuscate data transistively", () => {
-      const newDocument = wrapDocument(datum[2], { version: "https://schema.openattestation.com/3.0/schema.json" });
+      const newDocument = wrapDocument(datum[2], { version: SchemaId.v3 });
       const intermediateDocument = obfuscateDocument(newDocument, ["key2"]);
       const obfuscatedDocument = obfuscateDocument(intermediateDocument, ["key3"]);
 
@@ -176,7 +177,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("creates a batch of documents if all are in the right format", () => {
       const signedDocuments = wrapDocuments(datum, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "https://schema.openattestation.com/3.0/schema.json"
+        version: SchemaId.v3
       });
       signedDocuments.forEach((doc, i: number) => {
         expect(doc.schema).toBe("http://example.com/schema.json");
@@ -191,7 +192,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("checks that documents are wrapped correctly", () => {
       const signedDocuments = wrapDocuments(datum, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "https://schema.openattestation.com/3.0/schema.json"
+        version: SchemaId.v3
       });
       const verified = signedDocuments.reduce((prev, curr) => verifySignature(curr) && prev, true);
       expect(verified).toBe(true);
@@ -199,7 +200,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("checks that documents conforms to the schema", () => {
       const signedDocuments = wrapDocuments(datum, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "https://schema.openattestation.com/3.0/schema.json"
+        version: SchemaId.v3
       });
       const validatedSchema = signedDocuments.reduce((prev: boolean, curr: any) => validateSchema(curr) && prev, true);
       expect(validatedSchema).toBe(true);
@@ -208,7 +209,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("checks that data extracted are the same as input", () => {
       const signedDocuments = wrapDocuments(datum, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "https://schema.openattestation.com/3.0/schema.json"
+        version: SchemaId.v3
       });
       signedDocuments.forEach((doc, i: number) => {
         const data = getData(doc);
@@ -219,10 +220,10 @@ describe("v3 E2E Test Scenarios", () => {
     test("does not allow for same merkle root to be generated", () => {
       const signedDocuments = wrapDocuments(datum, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "https://schema.openattestation.com/3.0/schema.json"
+        version: SchemaId.v3
       });
       const newSignedDocuments = wrapDocuments(datum, {
-        version: "https://schema.openattestation.com/3.0/schema.json"
+        version: SchemaId.v3
       });
       expect(signedDocuments[0].signature.merkleRoot).not.toBe(newSignedDocuments[0].signature.merkleRoot);
     });
@@ -248,7 +249,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("should return false if document is not valid", () => {
       expect(
         validateSchema({
-          version: "https://schema.openattestation.com/3.0/schema.json",
+          version: SchemaId.v3,
           schema: "http://example.com/schemaV3.json",
           data: {
             key: 2
@@ -265,7 +266,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("should return true when document is valid and version is 3.0", () => {
       expect(
         validateSchema({
-          version: "https://schema.openattestation.com/3.0/schema.json",
+          version: SchemaId.v3,
           schema: "http://example.com/schemaV3.json",
           data: {
             reference: "reference",
@@ -302,7 +303,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("should return true when document is valid and version is 3.0 and identityProof is W3C-DID", () => {
       expect(
         validateSchema({
-          version: "https://schema.openattestation.com/3.0/schema.json",
+          version: SchemaId.v3,
           schema: "http://example.com/schemaV3.json",
           data: {
             reference: "reference",
@@ -339,7 +340,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("should return false when document is invalid due to no W3D-DID location", () => {
       expect(
         validateSchema({
-          version: "https://schema.openattestation.com/3.0/schema.json",
+          version: SchemaId.v3,
           schema: "http://example.com/schemaV3.json",
           data: {
             reference: "reference",

--- a/test/e2e.v3.test.ts
+++ b/test/e2e.v3.test.ts
@@ -6,7 +6,7 @@ import {
   ProofType,
   TemplateType
 } from "../src/__generated__/schemaV3";
-import {SchemaId} from "../src/@types/document"
+import { SchemaId } from "../src/@types/document";
 
 const openAttestationData: OpenAttestationDocument = {
   reference: "document identifier",

--- a/test/e2e.v3.test.ts
+++ b/test/e2e.v3.test.ts
@@ -221,7 +221,9 @@ describe("v3 E2E Test Scenarios", () => {
         externalSchemaId: "http://example.com/schema.json",
         version: "https://schema.openattestation.com/3.0/schema.json"
       });
-      const newSignedDocuments = wrapDocuments(datum, { version: "https://schema.openattestation.com/3.0/schema.json" });
+      const newSignedDocuments = wrapDocuments(datum, {
+        version: "https://schema.openattestation.com/3.0/schema.json"
+      });
       expect(signedDocuments[0].signature.merkleRoot).not.toBe(newSignedDocuments[0].signature.merkleRoot);
     });
   });

--- a/test/e2e.v3.test.ts
+++ b/test/e2e.v3.test.ts
@@ -82,7 +82,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("creates a wrapped document", () => {
       const wrappedDocument = wrapDocument(document, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "open-attestation/3.0"
+        version: "https://schema.openattestation.com/3.0/schema.json"
       });
       expect(wrappedDocument.schema).toBe("http://example.com/schema.json");
       expect(wrappedDocument.data.key1).toEqual(expect.stringContaining("test"));
@@ -95,7 +95,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("creates a wrapped document with W3C-DID IdentityProof", () => {
       const wrappedDocumentWithW3CDID = wrapDocument(openAttestationDataWithW3CDID, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "open-attestation/3.0"
+        version: "https://schema.openattestation.com/3.0/schema.json"
       });
       expect(wrappedDocumentWithW3CDID.schema).toBe("http://example.com/schema.json");
       expect(wrappedDocumentWithW3CDID.signature.type).toBe("SHA3MerkleProof");
@@ -111,7 +111,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("checks that document is wrapped correctly", () => {
       const wrappedDocument = wrapDocument(document, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "open-attestation/3.0"
+        version: "https://schema.openattestation.com/3.0/schema.json"
       });
       const verified = verifySignature(wrappedDocument);
       expect(verified).toBe(true);
@@ -119,7 +119,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("checks that document conforms to the schema", () => {
       const wrappedDocument = wrapDocument(document, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "open-attestation/3.0"
+        version: "https://schema.openattestation.com/3.0/schema.json"
       });
       expect(validateSchema(wrappedDocument)).toBe(true);
     });
@@ -127,7 +127,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("checks that data extracted are the same as input", () => {
       const wrappedDocument = wrapDocument(document, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "open-attestation/3.0"
+        version: "https://schema.openattestation.com/3.0/schema.json"
       });
       const data = getData(wrappedDocument);
       expect(data).toEqual(datum[0]);
@@ -136,14 +136,14 @@ describe("v3 E2E Test Scenarios", () => {
     test("does not allow for the same merkle root to be generated", () => {
       const wrappedDocument = wrapDocument(document, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "open-attestation/3.0"
+        version: "https://schema.openattestation.com/3.0/schema.json"
       });
-      const newDocument = wrapDocument(document, { version: "open-attestation/3.0" });
+      const newDocument = wrapDocument(document, { version: "https://schema.openattestation.com/3.0/schema.json" });
       expect(wrappedDocument.signature.merkleRoot).not.toBe(newDocument.signature.merkleRoot);
     });
 
     test("obfuscate data correctly", async () => {
-      const newDocument = wrapDocument(datum[2], { version: "open-attestation/3.0" });
+      const newDocument = wrapDocument(datum[2], { version: "https://schema.openattestation.com/3.0/schema.json" });
       const obfuscatedDocument = obfuscateDocument(newDocument, ["key2"]);
 
       const verified = verifySignature(obfuscatedDocument);
@@ -152,7 +152,7 @@ describe("v3 E2E Test Scenarios", () => {
     });
 
     test("obfuscate data transistively", () => {
-      const newDocument = wrapDocument(datum[2], { version: "open-attestation/3.0" });
+      const newDocument = wrapDocument(datum[2], { version: "https://schema.openattestation.com/3.0/schema.json" });
       const intermediateDocument = obfuscateDocument(newDocument, ["key2"]);
       const obfuscatedDocument = obfuscateDocument(intermediateDocument, ["key3"]);
 
@@ -176,7 +176,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("creates a batch of documents if all are in the right format", () => {
       const signedDocuments = wrapDocuments(datum, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "open-attestation/3.0"
+        version: "https://schema.openattestation.com/3.0/schema.json"
       });
       signedDocuments.forEach((doc, i: number) => {
         expect(doc.schema).toBe("http://example.com/schema.json");
@@ -191,7 +191,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("checks that documents are wrapped correctly", () => {
       const signedDocuments = wrapDocuments(datum, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "open-attestation/3.0"
+        version: "https://schema.openattestation.com/3.0/schema.json"
       });
       const verified = signedDocuments.reduce((prev, curr) => verifySignature(curr) && prev, true);
       expect(verified).toBe(true);
@@ -199,7 +199,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("checks that documents conforms to the schema", () => {
       const signedDocuments = wrapDocuments(datum, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "open-attestation/3.0"
+        version: "https://schema.openattestation.com/3.0/schema.json"
       });
       const validatedSchema = signedDocuments.reduce((prev: boolean, curr: any) => validateSchema(curr) && prev, true);
       expect(validatedSchema).toBe(true);
@@ -208,7 +208,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("checks that data extracted are the same as input", () => {
       const signedDocuments = wrapDocuments(datum, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "open-attestation/3.0"
+        version: "https://schema.openattestation.com/3.0/schema.json"
       });
       signedDocuments.forEach((doc, i: number) => {
         const data = getData(doc);
@@ -219,9 +219,9 @@ describe("v3 E2E Test Scenarios", () => {
     test("does not allow for same merkle root to be generated", () => {
       const signedDocuments = wrapDocuments(datum, {
         externalSchemaId: "http://example.com/schema.json",
-        version: "open-attestation/3.0"
+        version: "https://schema.openattestation.com/3.0/schema.json"
       });
-      const newSignedDocuments = wrapDocuments(datum, { version: "open-attestation/3.0" });
+      const newSignedDocuments = wrapDocuments(datum, { version: "https://schema.openattestation.com/3.0/schema.json" });
       expect(signedDocuments[0].signature.merkleRoot).not.toBe(newSignedDocuments[0].signature.merkleRoot);
     });
   });
@@ -246,7 +246,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("should return false if document is not valid", () => {
       expect(
         validateSchema({
-          version: "open-attestation/3.0",
+          version: "https://schema.openattestation.com/3.0/schema.json",
           schema: "http://example.com/schemaV3.json",
           data: {
             key: 2
@@ -263,7 +263,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("should return true when document is valid and version is 3.0", () => {
       expect(
         validateSchema({
-          version: "open-attestation/3.0",
+          version: "https://schema.openattestation.com/3.0/schema.json",
           schema: "http://example.com/schemaV3.json",
           data: {
             reference: "reference",
@@ -300,7 +300,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("should return true when document is valid and version is 3.0 and identityProof is W3C-DID", () => {
       expect(
         validateSchema({
-          version: "open-attestation/3.0",
+          version: "https://schema.openattestation.com/3.0/schema.json",
           schema: "http://example.com/schemaV3.json",
           data: {
             reference: "reference",
@@ -337,7 +337,7 @@ describe("v3 E2E Test Scenarios", () => {
     test("should return false when document is invalid due to no W3D-DID location", () => {
       expect(
         validateSchema({
-          version: "open-attestation/3.0",
+          version: "https://schema.openattestation.com/3.0/schema.json",
           schema: "http://example.com/schemaV3.json",
           data: {
             reference: "reference",


### PR DESCRIPTION
Updated the schema id `$id`:

- from `open-attestation/2.0` to `https://schema.openattestation.com/2.0/schema.json` 
- from `open-attestation/3.0` to `https://schema.openattestation.com/3.0/schema.json` 

This will make the schema JSON schema compliant so that online JSON schema validator will not complain about the malformed schema and that we will have a permalink to reference the schema in our documentations as well.

Additionally added the long url as enums to the @type/document to prevent lots of copy-pasted urls in the code.