### PR TITLE
feat: strict schema typing

### DIFF
--- a/src/@types/document.ts
+++ b/src/@types/document.ts
@@ -17,7 +17,7 @@ export interface ObfuscationMetadata {
 }
 
 export interface SchematisedDocument<T = any> {
-  version: string;
+  version: SchemaId;
   data: DeepStringify<T>;
   schema?: string;
   privacy?: ObfuscationMetadata;

--- a/src/digest/digest.test.ts
+++ b/src/digest/digest.test.ts
@@ -1,5 +1,5 @@
 import { digestDocument, flattenHashArray } from "./digest";
-import { SchematisedDocument } from "../@types/document";
+import { SchematisedDocument, SchemaId } from "../@types/document";
 
 describe("digest", () => {
   describe("flattenHashArray", () => {
@@ -83,7 +83,7 @@ describe("digest", () => {
   describe("digestDocument", () => {
     test("digests a document with all visible content correctly", () => {
       const document: SchematisedDocument = {
-        version: "1.0",
+        version: SchemaId.v2,
         schema: "foo",
         data: {
           key1: "value1",
@@ -102,7 +102,7 @@ describe("digest", () => {
 
     it("handles shadowed keys correctly", () => {
       const documentWithShadowedKey: SchematisedDocument = {
-        version: "1.0",
+        version: SchemaId.v2,
         schema: "foo",
         data: {
           foo: {
@@ -119,7 +119,7 @@ describe("digest", () => {
 
     test("digests a document with some visible content correctly", () => {
       const document: SchematisedDocument = {
-        version: "1.0",
+        version: SchemaId.v2,
         schema: "foo",
         data: {
           key1: "value1",
@@ -145,7 +145,7 @@ describe("digest", () => {
 
     test("digests a document with no visible content correctly", () => {
       const document: SchematisedDocument = {
-        version: "1.0",
+        version: SchemaId.v2,
         schema: "foo",
         data: {},
         privacy: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,3 +72,4 @@ export * from "./schema/3.0/w3c";
 export { getData } from "./utils"; // keep it to avoid breaking change, moved from privacy to utils
 export { v2 };
 export { v3 };
+export { SchemaId };

--- a/src/signature/signature.test.ts
+++ b/src/signature/signature.test.ts
@@ -1,8 +1,8 @@
 import { wrap, verify } from "./signature";
-import { SchematisedDocument } from "../@types/document";
+import { SchematisedDocument, SchemaId } from "../@types/document";
 
 const unwrappedDocument: SchematisedDocument = {
-  version: "1.0",
+  version: SchemaId.v2,
   schema: "foo",
   data: {
     key1: "value1",


### PR DESCRIPTION
This PR introduces stricter types on the `version` string
of the OA document. Random strings will no longer be
accepted. At the same time, the SchemaId is exported to
allow dependencies to use the enum values.

- stricter type on `version`
- exports SchemaId

OA documents using the old version string will be invalidated