### PR TITLE
feat: added w3c context checker in wrap

### DIFF
--- a/src/v3/schema/schema.test.ts
+++ b/src/v3/schema/schema.test.ts
@@ -36,8 +36,26 @@ describe("schema/v3.0", () => {
         "https://www.w3.org/2018/credentials/v1 needs to be first in the list of contexts"
       );
     });
+    it("should be invalid when @context is a string", async () => {
+      // @context MUST be an ordered set in W3C VC data model, see https://www.w3.org/TR/vc-data-model/#contexts
+      const document = { ...cloneDeep(sampleDoc), "@context": "https://www.w3.org/2018/credentials/v1" };
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore
+      await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
+        "validationErrors",
+        [
+          {
+            keyword: "type",
+            dataPath: "['@context']",
+            schemaPath: "#/properties/%40context/type",
+            params: { type: "array" },
+            message: "should be array"
+          }
+        ]
+      );
+    });
     it("should be invalid when @context has https://www.w3.org/2018/credentials/v1 but is not the first", async () => {
-      // This should not have AJV validation errors as it's only caught after
+      // This should not have AJV validation errors as it's only caught during validateW3C
       const document = {
         ...cloneDeep(sampleDoc),
         "@context": ["https://www.w3.org/2018/credentials/examples/v1", "https://www.w3.org/2018/credentials/v1"]

--- a/src/v3/schema/schema.test.ts
+++ b/src/v3/schema/schema.test.ts
@@ -143,7 +143,7 @@ describe("schema/v3.0", () => {
       // But if reference is given, it should not be null as we cannot salt null values
       expect.assertions(1);
       const document = { ...cloneDeep(sampleDoc), reference: null };
-      // @ts-expect-error reference must be undefined or null
+      // @ts-expect-error reference cannot be undefined or null
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
         "message",
         "Cannot convert undefined or null to object"
@@ -173,7 +173,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if name is null", async () => {
       expect.assertions(1);
       const document = { ...cloneDeep(sampleDoc), name: null };
-      // @ts-expect-error
+      // @ts-expect-error name cannot be undefined or null
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
         "message",
         "Cannot convert undefined or null to object"
@@ -185,7 +185,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if type is null", async () => {
       expect.assertions(1);
       const document = { ...cloneDeep(sampleDoc), type: null };
-      // @ts-expect-error
+      // @ts-expect-error type cannot be undefined or null
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
         "message",
         "Cannot convert undefined or null to object"
@@ -232,7 +232,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if validFrom is null", async () => {
       expect.assertions(1);
       const document = { ...cloneDeep(sampleDoc), validFrom: null };
-      // @ts-expect-error
+      // @ts-expect-error validFrom cannot be undefined or null
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
         "message",
         "Cannot convert undefined or null to object"
@@ -279,7 +279,7 @@ describe("schema/v3.0", () => {
     it("should be invalid when validUntil is null", async () => {
       expect.assertions(1);
       const document = { ...cloneDeep(sampleDoc), validUntil: null };
-      // @ts-expect-error
+      // @ts-expect-error validUntil cannot be undefined or null
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
         "message",
         "Cannot convert undefined or null to object"
@@ -353,8 +353,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if template is missing", async () => {
       expect.assertions(1);
       const document = { ...omit(cloneDeep(sampleDoc), "template") };
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error template cannot be undefined or null
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
         "validationErrors",
         [
@@ -403,7 +402,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if template.type is not equal to EMBEDDED_RENDERER", async () => {
       expect.assertions(2);
       const document = { ...cloneDeep(sampleDoc), template: { ...sampleDoc.template } };
-      // @ts-expect-error
+      // @ts-expect-error SOMETHING cannot be assigned to template.type
       document.template.type = "SOMETHING";
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -647,7 +646,7 @@ describe("schema/v3.0", () => {
       const document = {
         ...cloneDeep(sampleDoc)
       };
-      // @ts-expect-error
+      // @ts-expect-error OTHER cannot be assigned to issuer.identityProof.type
       document.issuer.identityProof.type = "OTHER";
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -810,7 +809,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if proof type is not OpenAttestationProofMethod", async () => {
       expect.assertions(2);
       const document = { ...cloneDeep(sampleDoc) };
-      // @ts-expect-error
+      // @ts-expect-error Something cannot be assigned to oaProof.type
       document.oaProof.type = "Something";
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -849,7 +848,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if proof type is not TOKEN_REGISTRY or DOCUMENT_STORE", async () => {
       expect.assertions(2);
       const document = { ...cloneDeep(sampleDoc), oaProof: { ...sampleDoc.oaProof } };
-      // @ts-expect-error
+      // @ts-expect-error Something cannot be assigned to oaProof.method
       document.oaProof.method = "Something";
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -891,31 +890,31 @@ describe("schema/v3.0", () => {
     it("should be valid when mimeType is application/pdf", async () => {
       const document = {
         ...cloneDeep(sampleDoc),
-        // @ts-expect-error
+        // @ts-expect-error evidence is possibly undefined
         evidence: [{ ...sampleDoc.evidence[0], mimeType: "application/pdf" }]
       };
-      // @ts-expect-error
+      // @ts-expect-error mimeType cannot be a string "application/pdf"
       const wrappedDocument = await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when mimeType is image/png", async () => {
-      // @ts-expect-error
+      // @ts-expect-error evidence is possibly undefined
       const document = { ...cloneDeep(sampleDoc), evidence: [{ ...sampleDoc.evidence[0], mimeType: "image/png" }] };
-      // @ts-expect-error
+      // @ts-expect-error mimeType cannot be a string "image/png"
       const wrappedDocument = await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when mimeType is image/jpeg", async () => {
-      // @ts-expect-error
+      // @ts-expect-error evidence is possibly undefined
       const document = { ...cloneDeep(sampleDoc), evidence: [{ ...sampleDoc.evidence[0], mimeType: "image/jpeg" }] };
-      // @ts-expect-error
+      // @ts-expect-error mimeType cannot be a string "image/jpeg"
       const wrappedDocument = await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
 
     it("should be invalid when adding additional data", async () => {
       expect.assertions(2);
-      // @ts-expect-error
+      // @ts-expect-error evidence is possibly undefined
       const document = { ...cloneDeep(sampleDoc), evidence: [{ ...sampleDoc.evidence[0], key: "any" }] };
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });

--- a/src/v3/schema/schema.test.ts
+++ b/src/v3/schema/schema.test.ts
@@ -39,8 +39,7 @@ describe("schema/v3.0", () => {
     it("should be invalid when @context is a string", async () => {
       // @context MUST be an ordered set in W3C VC data model, see https://www.w3.org/TR/vc-data-model/#contexts
       const document = { ...cloneDeep(sampleDoc), "@context": "https://www.w3.org/2018/credentials/v1" };
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
         "validationErrors",
         [
@@ -174,9 +173,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if name is null", async () => {
       expect.assertions(1);
       const document = { ...cloneDeep(sampleDoc), name: null };
-      // TODO FIXME <- ASK LAURENT: what's this
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
         "message",
         "Cannot convert undefined or null to object"
@@ -188,9 +185,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if type is null", async () => {
       expect.assertions(1);
       const document = { ...cloneDeep(sampleDoc), type: null };
-      // TODO FIXME <- ASK LAURENT: what's this
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
         "message",
         "Cannot convert undefined or null to object"
@@ -237,8 +232,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if validFrom is null", async () => {
       expect.assertions(1);
       const document = { ...cloneDeep(sampleDoc), validFrom: null };
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
         "message",
         "Cannot convert undefined or null to object"
@@ -285,8 +279,7 @@ describe("schema/v3.0", () => {
     it("should be invalid when validUntil is null", async () => {
       expect.assertions(1);
       const document = { ...cloneDeep(sampleDoc), validUntil: null };
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
         "message",
         "Cannot convert undefined or null to object"
@@ -410,9 +403,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if template.type is not equal to EMBEDDED_RENDERER", async () => {
       expect.assertions(2);
       const document = { ...cloneDeep(sampleDoc), template: { ...sampleDoc.template } };
-      // TODO FIXME <- ASK LAURENT: why though
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       document.template.type = "SOMETHING";
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -473,9 +464,6 @@ describe("schema/v3.0", () => {
     it("should be valid when id is an URI", async () => {
       const document = {
         ...cloneDeep(sampleDoc),
-        // TODO FIXME
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore
         issuer: { ...sampleDoc.issuer, id: "http://example.com" }
       };
       const wrappedDocument = await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -483,9 +471,6 @@ describe("schema/v3.0", () => {
     });
     it("should be invalid when adding additional data", async () => {
       expect.assertions(2);
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
       const document = { ...cloneDeep(sampleDoc), issuer: { ...sampleDoc.issuer, key: "any" } };
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -518,9 +503,6 @@ describe("schema/v3.0", () => {
     });
     it("should be invalid when id is not a URI", async () => {
       expect.assertions(2);
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
       const document = { ...cloneDeep(sampleDoc), issuer: { ...sampleDoc.issuer, id: "" } };
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -573,9 +555,6 @@ describe("schema/v3.0", () => {
     it("should be invalid if issuer has no name", async () => {
       expect.assertions(2);
       const document = { ...cloneDeep(sampleDoc) };
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
       delete document.issuer.name;
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -609,9 +588,6 @@ describe("schema/v3.0", () => {
     it("should be invalid if issuer has no id", async () => {
       expect.assertions(2);
       const document = { ...cloneDeep(sampleDoc) };
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
       delete document.issuer.id;
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -671,9 +647,7 @@ describe("schema/v3.0", () => {
       const document = {
         ...cloneDeep(sampleDoc)
       };
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       document.issuer.identityProof.type = "OTHER";
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -917,45 +891,31 @@ describe("schema/v3.0", () => {
     it("should be valid when mimeType is application/pdf", async () => {
       const document = {
         ...cloneDeep(sampleDoc),
-        // TODO FIXME
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore
+        // @ts-expect-error
         evidence: [{ ...sampleDoc.evidence[0], mimeType: "application/pdf" }]
       };
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       const wrappedDocument = await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when mimeType is image/png", async () => {
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       const document = { ...cloneDeep(sampleDoc), evidence: [{ ...sampleDoc.evidence[0], mimeType: "image/png" }] };
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       const wrappedDocument = await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
     it("should be valid when mimeType is image/jpeg", async () => {
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       const document = { ...cloneDeep(sampleDoc), evidence: [{ ...sampleDoc.evidence[0], mimeType: "image/jpeg" }] };
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       const wrappedDocument = await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
 
     it("should be invalid when adding additional data", async () => {
       expect.assertions(2);
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       const document = { ...cloneDeep(sampleDoc), evidence: [{ ...sampleDoc.evidence[0], key: "any" }] };
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -975,9 +935,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if filename is missing", async () => {
       expect.assertions(2);
       const document = { ...cloneDeep(sampleDoc) };
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       delete document.evidence[0].fileName;
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -997,9 +955,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if mimeType is missing", async () => {
       expect.assertions(2);
       const document = { ...cloneDeep(sampleDoc) };
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       delete document.evidence[0].mimeType;
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -1019,9 +975,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if mimeType is not one of the specified enum value", async () => {
       expect.assertions(2);
       const document = { ...cloneDeep(sampleDoc) };
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       document.evidence[0].mimeType = "Something";
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -1041,9 +995,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if data is missing", async () => {
       expect.assertions(2);
       const document = { ...cloneDeep(sampleDoc) };
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       delete document.evidence[0].data;
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
@@ -1063,9 +1015,7 @@ describe("schema/v3.0", () => {
     it("should be invalid if type is missing", async () => {
       expect.assertions(2);
       const document = { ...cloneDeep(sampleDoc) };
-      // TODO FIXME
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
+      // @ts-expect-error
       delete document.evidence[0].type;
       try {
         await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });

--- a/src/v3/wrap.ts
+++ b/src/v3/wrap.ts
@@ -32,14 +32,14 @@ export const wrap = <T extends OpenAttestationVerifiableCredentialWithoutProof>(
   document: T
 ): OpenAttestationVerifiableCredential<T> => {
   // To ensure that base @context exists, but this also means some of our validateW3C errors may be unreachable
-  if (document["@context"] == undefined) {
+  if (!document["@context"]) {
     document["@context"] = ["https://www.w3.org/2018/credentials/v1"];
   }
 
   // Since our wrapper adds in OA-specific properties, we should push our OA context. This is also to pass W3C VC test suite.
   if (
     Array.isArray(document["@context"]) &&
-    !("https://nebulis.github.io/tmp-jsonld/OpenAttestation.v3.jsonld" in document["@context"])
+    !document["@context"].includes("https://nebulis.github.io/tmp-jsonld/OpenAttestation.v3.jsonld")
   ) {
     document["@context"].push("https://nebulis.github.io/tmp-jsonld/OpenAttestation.v3.jsonld");
   }

--- a/src/v3/wrap.ts
+++ b/src/v3/wrap.ts
@@ -26,20 +26,24 @@ export const salt = (data: any) => deepMap(data, "");
 
 /**
  * Wrap a single OpenAttestation document in v3 format.
- * @param document
+ * @param document an unwrapped OpenAttestation document
  */
 export const wrap = <T extends OpenAttestationVerifiableCredentialWithoutProof>(
   document: T
 ): OpenAttestationVerifiableCredential<T> => {
-  //ASK LAURENT: Should we have this? To ensure @context exists
-  // if (document["@context"] == undefined) {
-  //   document["@context"] = ["https://www.w3.org/2018/credentials/v1"];
-  // }
+  // To ensure that base @context exists, but this also means some of our validateW3C errors may be unreachable
+  if (document["@context"] == undefined) {
+    document["@context"] = ["https://www.w3.org/2018/credentials/v1"];
+  }
 
-  //ASK LAURENT: Push in user defined @contexts?
-  // document["@context"].push(
-  //   "https://gist.githubusercontent.com/Nebulis/18efab9f8801c886a7dd0f6230efd89d/raw/f9f3107cabd7768f84a36c65d756abd961d19bda/w3c.json.ld",
-  // );
+  // Since our wrapper adds in OA-specific properties, we should push our OA context. This is also to pass W3C VC test suite.
+  if (
+    Array.isArray(document["@context"]) &&
+    !("https://nebulis.github.io/tmp-jsonld/OpenAttestation.v3.jsonld" in document["@context"])
+  ) {
+    document["@context"].push("https://nebulis.github.io/tmp-jsonld/OpenAttestation.v3.jsonld");
+  }
+
   const salts = salt(document);
   const digest = digestDocument(document, salts, []);
 
@@ -66,7 +70,7 @@ export const wrap = <T extends OpenAttestationVerifiableCredentialWithoutProof>(
 
 /**
  * Wrap multiple OpenAttestation documents in v3 format.
- * @param documents
+ * @param documents an array of unwrapped OpenAttestation documents
  */
 export const wraps = <T extends OpenAttestationVerifiableCredentialWithoutProof>(
   documents: T[]


### PR DESCRIPTION
### wrap.ts

Since our wrapper adds OA-specific properties, I feel that we should check if the OA v3 context is missing or not. In the original unwrapped document, the user can:

- choose to add in the OA v3 context, then `wrap` will not add it in
- choose not to add in the OA v3 context, then `wrap` will add it in

_(This is also to ensure we can pass the W3C test inputs since the original inputs does not come with OA v3's context)_

This is the logic:

> If `@context` doesn't exist (i.e. `undefined`):
> 
> - `wrap` will create the `@context` array with `https://www.w3.org/2018/credentials/v1` as the first item
> 
> _(Now this would mean that some `@context` validations check in `validateW3C` may be unreachable)_
> 
> Next, if `@context` exists and is an array, and if OA v3 contexts is not in the original `@context`:
> 
> - then we add it in for them

But I believe this is something to be discussed.

Also added a new testcase to improve test coverage in case `@context` is a string.