### PR TITLE
chore: check on using multiple types in json schema

### DIFF
--- a/src/shared/utils/utils.test.ts
+++ b/src/shared/utils/utils.test.ts
@@ -200,7 +200,7 @@ describe("Util Functions", () => {
           },
           oaProof: {
             value: "0xabcf",
-            type: OaProofType.OpenAttestationSignature2018,
+            type: OaProofType.OpenAttestationProofMethod,
             method: Method.DocumentStore
           },
           name: "",

--- a/src/v3/digest/digest.test.ts
+++ b/src/v3/digest/digest.test.ts
@@ -27,7 +27,7 @@ describe("digest v3.0", () => {
           url: "https://renderer.openattestation.com/"
         },
         oaProof: {
-          type: OaProofType.OpenAttestationSignature2018,
+          type: OaProofType.OpenAttestationProofMethod,
           method: Method.DocumentStore,
           value: ""
         }

--- a/src/v3/schema/sample-document.json
+++ b/src/v3/schema/sample-document.json
@@ -37,7 +37,7 @@
     "url": "https://localhost:3000/renderer"
   },
   "oaProof": {
-    "type": "OpenAttestationSignature2018",
+    "type": "OpenAttestationProofMethod",
     "method": "DOCUMENT_STORE",
     "value": "0x9178F546D3FF57D7A6352bD61B80cCCD46199C2d"
   },

--- a/src/v3/schema/schema.json
+++ b/src/v3/schema/schema.json
@@ -4,6 +4,19 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "definitions": {
+    "type": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
     "issuer": {
       "type": "object",
       "properties": {
@@ -51,17 +64,7 @@
       "description": "URI to the subject of the credential as explained by https://www.w3.org/TR/vc-data-model/#credential-subject"
     },
     "type": {
-      "oneOf": [
-        {
-          "type": "array"
-        },
-        {
-          "type": "string"
-        }
-      ],
-      "items": {
-        "type": "string"
-      },
+      "$ref": "#/definitions/type",
       "description": "Specific verifiable credential type as explained by https://www.w3.org/TR/vc-data-model/#types"
     },
     "reference": {
@@ -103,7 +106,10 @@
           "type": "object"
         },
         {
-          "type": "array"
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
         }
       ]
     },
@@ -144,7 +150,7 @@
         "type": {
           "type": "string",
           "description": "Proof method name as explained by https://www.w3.org/TR/vc-data-model/#types",
-          "enum": ["OpenAttestationSignature2018"]
+          "enum": ["OpenAttestationProofMethod"]
         },
         "method": {
           "type": "string",
@@ -184,17 +190,7 @@
             "description": "Name of this attachment, with appropriate extensions"
           },
           "type": {
-            "oneOf": [
-              {
-                "type": "array"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "items": {
-              "type": "string"
-            },
+            "$ref": "#/definitions/type",
             "description": "Specific evidence type as explained by https://www.w3.org/TR/vc-data-model/#types"
           },
           "mimeType": {

--- a/src/v3/schema/schema.test.ts
+++ b/src/v3/schema/schema.test.ts
@@ -728,7 +728,7 @@ describe("schema/v3.0", () => {
       const wrappedDocument = await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
     });
-    it("should be valid when type is OpenAttestationSignature2018", async () => {
+    it("should be valid when type is OpenAttestationProofMethod", async () => {
       const document = { ...cloneDeep(sampleDoc) };
       const wrappedDocument = await wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 });
       expect(wrappedDocument.version).toStrictEqual(SchemaId.v3);
@@ -815,7 +815,7 @@ describe("schema/v3.0", () => {
         ]);
       }
     });
-    it("should be invalid if proof type is not OpenAttestationSignature2018", async () => {
+    it("should be invalid if proof type is not OpenAttestationProofMethod", async () => {
       expect.assertions(2);
       const document = { ...cloneDeep(sampleDoc) };
       // @ts-expect-error
@@ -829,7 +829,7 @@ describe("schema/v3.0", () => {
             keyword: "enum",
             dataPath: ".oaProof.type",
             schemaPath: "#/properties/oaProof/properties/type/enum",
-            params: { allowedValues: ["OpenAttestationSignature2018"] },
+            params: { allowedValues: ["OpenAttestationProofMethod"] },
             message: "should be equal to one of the allowed values"
           }
         ]);

--- a/test/e2e.v3.test.ts
+++ b/test/e2e.v3.test.ts
@@ -46,7 +46,7 @@ const openAttestationData: OpenAttestationCredentialWithInnerIssuer = {
     }
   },
   oaProof: {
-    type: OaProofType.OpenAttestationSignature2018,
+    type: OaProofType.OpenAttestationProofMethod,
     value: "0x9178F546D3FF57D7A6352bD61B80cCCD46199C2d",
     method: Method.TokenRegistry
   }
@@ -313,7 +313,7 @@ describe("v3 E2E Test Scenarios", () => {
             url: "https://localhost:3000/renderer"
           },
           oaProof: {
-            type: "OpenAttestationSignature2018",
+            type: "OpenAttestationProofMethod",
             method: "DOCUMENT_STORE",
             value: "0x9178F546D3FF57D7A6352bD61B80cCCD46199C2d"
           },
@@ -364,7 +364,7 @@ describe("v3 E2E Test Scenarios", () => {
             url: "https://example.com"
           },
           oaProof: {
-            type: "OpenAttestationSignature2018",
+            type: OaProofType.OpenAttestationProofMethod,
             method: "TOKEN_REGISTRY",
             value: "proof.value"
           },
@@ -399,7 +399,7 @@ describe("v3 E2E Test Scenarios", () => {
               url: "https://example.com"
             },
             proof: {
-              type: "OpenAttestationSignature2018",
+              type: OaProofType.OpenAttestationProofMethod,
               method: "TOKEN_REGISTRY",
               value: "proof.value"
             }


### PR DESCRIPTION
- Changed type OpenAttestationSignature2018 to OpenAttestationProofMethod
- Created type definition in json schema which can be a string or an array of string
