### PR TITLE
Feat/w3c/verify

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import Ajv from "ajv";
 import { digestDocument as digestDocumentV2 } from "./v2/digest";
 import { getSchema, validateSchema as validate, validateW3C } from "./shared/validate";
 import { verify } from "./v2/verify";
-import { verifyV3 } from "./v3/verify";
+import { verify as verifyV3 } from "./v3/verify";
 import { wrap } from "./v2/wrap";
 import { wrap as wrapV3, wraps as wrapsV3 } from "./v3/wrap";
 import {

--- a/src/v3/verify.ts
+++ b/src/v3/verify.ts
@@ -1,37 +1,24 @@
-import { bufSortJoin, hashToBuffer } from "../shared/utils";
 import { OpenAttestationVerifiableCredential } from "../shared/@types/document";
-import { keccak256 } from "js-sha3";
 import { digestDocument as digestDocumentV3 } from "./digest";
+import { checkProof } from "../shared/merkle";
 
-export const verifyV3 = <T extends OpenAttestationVerifiableCredential>(
+export const verify = <T extends OpenAttestationVerifiableCredential>(
   document: T
 ): document is OpenAttestationVerifiableCredential<T> => {
-  const signature = document.proof;
-  if (!signature) {
+  if (!document.proof) {
     return false;
   }
 
+  // remove proof from document
+  // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
+  const { proof, ...documentWithoutProof } = document;
+
   // Checks target hash
-  const bla = {
-    ...document,
-    proof: {
-      ...document.proof,
-      signature: undefined
-    }
-  };
-  const digest = digestDocumentV3(bla, document.proof.salts, document.proof.privacy.obfuscated);
+  const digest = digestDocumentV3(documentWithoutProof, document.proof.salts, document.proof.privacy.obfuscated);
   const targetHash = document.proof.targetHash;
   if (digest !== targetHash) return false;
 
   // Calculates merkle root from target hash and proof, then compare to merkle root in document
-  const merkleRoot = document.proof.merkleRoot;
-  const proofs: string[] = document.proof.proofs;
-  const calculatedMerkleRoot = proofs.reduce((prev, current) => {
-    const prevAsBuffer = hashToBuffer(prev);
-    const currAsBuffer = hashToBuffer(current);
-    const combineAsBuffer = bufSortJoin(prevAsBuffer, currAsBuffer);
-    return keccak256(combineAsBuffer);
-  }, digest);
 
-  return calculatedMerkleRoot === merkleRoot;
+  return checkProof(document.proof.proofs, document.proof.merkleRoot, document.proof.targetHash);
 };


### PR DESCRIPTION
wouldn't it be the same to replace this https://github.com/Open-Attestation/open-attestation/blob/master/src/signature/signature.ts#L49

by calling https://github.com/Open-Attestation/open-attestation/blob/master/src/signature/merkle/merkle.ts#L105

that way:

```
checkProof(document.signature.proof, document.signature.merkleRoot, document.signature.targetHash)
```