### PR TITLE
feat: test case coverage for digest, salt

### DIFF
--- a/src/v3/digest/digest.test.ts
+++ b/src/v3/digest/digest.test.ts
@@ -52,29 +52,94 @@ describe("digest v3.0", () => {
       const expectedDigest = "100ffe750d2ac887d9c4def00849dc7c08b21bba4a351883a6fc57b8c12d7474";
       expect(digest).toEqual(expectedDigest);
     });
-    test("handles shadowed keys correctly", () => {
-      const document = { ...cloneDeep(sampleDoc), "oaProof.value": "0xSomeMaliciousDocumentStore" };
+  });
+
+  describe("salt", () => {
+    test("handles shadowed keys correctly (type 1: root, dot notation)", () => {
+      const document = {
+        ...cloneDeep(sampleDoc),
+        "oaProof.value": "0xSomeMaliciousDocumentStore, this would be at oaProof.value after flatMap if uncaught"
+      };
       expect(() => {
         salt(document);
       }).toThrow("Key names must not have . in them");
     });
-    test("handles shadowed keys correctly (nested)", () => {
-      const document = { ...cloneDeep(sampleDoc), nested: { "oaProof.value": "0xSomeMaliciousDocumentStore" } };
+    test("handles shadowed keys correctly (type 2: root, array index)", () => {
+      const document = {
+        ...cloneDeep(sampleDoc),
+        "type[1]": "MaliciousCredential, this would be at type[1] after flatMap if uncaught"
+      };
+      expect(() => {
+        salt(document);
+      }).toThrow("Key names must not have '[' or ']' in them");
+    });
+    test("handles shadowed keys correctly (type 3: nested as object, dot notation)", () => {
+      const document = {
+        ...cloneDeep(sampleDoc),
+        nested: {
+          "oaProof.value":
+            "0xSomeMaliciousDocumentStore, this would be at nested.oaProof.value after flatMap if uncaught"
+        }
+      };
       expect(() => {
         salt(document);
       }).toThrow("Key names must not have . in them");
     });
-    test("handles shadowed keys correctly (array)", () => {
-      const document = { ...cloneDeep(sampleDoc), "type[1]": "MaliciousCredential" };
+    test("handles shadowed keys correctly (type 4: nested as object, array index)", () => {
+      const document = {
+        ...cloneDeep(sampleDoc),
+        nested: { "type[1]": "this would be at nested.type[1] after flatMap if uncaught" }
+      };
       expect(() => {
         salt(document);
       }).toThrow("Key names must not have '[' or ']' in them");
     });
-    test("handles shadowed keys correctly (nested array)", () => {
-      const document = { ...cloneDeep(sampleDoc), nested: { "type[1]": "hmm" } };
+    test("handles shadowed keys correctly (type 5: nested as array, dot notation)", () => {
+      const document = {
+        ...cloneDeep(sampleDoc),
+        nested: [{ "shadowed.key": "this would be at nested[0].shadowed.key after flatMap if uncaught" }]
+      };
+      expect(() => {
+        salt(document);
+      }).toThrow("Key names must not have . in them");
+    });
+    test("handles shadowed keys correctly (type 6: nested as array, array index)", () => {
+      const document = {
+        ...cloneDeep(sampleDoc),
+        nested: [{ "type[1]": "this would be at nested[0].type[1] after flatMap if uncaught" }]
+      };
       expect(() => {
         salt(document);
       }).toThrow("Key names must not have '[' or ']' in them");
+    });
+
+    test("handles null values correctly", () => {
+      const document = {
+        ...cloneDeep(sampleDoc),
+        grades: null
+      };
+      expect(() => {
+        salt(document);
+      }).toThrow("Cannot convert undefined or null to object");
+    });
+    test("handles undefined values correctly", () => {
+      // TODO: check on how we handle undefined vs. null
+      const document = {
+        ...cloneDeep(sampleDoc),
+        grades: undefined
+      };
+      expect(() => {
+        salt(document);
+      }).toThrow("Unexpected value 'undefined' in 'grades'"); // Cannot convert undefined or null to object?
+    });
+    test("handles funny stuff correctly (TODO)", () => {
+      const document = {
+        ...cloneDeep(sampleDoc),
+        grades: ["A+", 100, 50.28, undefined, "B+"]
+      };
+      expect(() => {
+        salt(document);
+      }).toThrow("Unexpected value 'undefined' in 'grades[3]'");
     });
   });
 });

--- a/src/v3/digest/digest.test.ts
+++ b/src/v3/digest/digest.test.ts
@@ -1,41 +1,80 @@
+import { cloneDeep } from "lodash";
 import { digestDocument } from "./digest";
+import { Method, OaProofType, TemplateType, OpenAttestationCredential } from "../../__generated__/schemaV3";
 import { salt } from "../wrap";
-import { Method, OaProofType, TemplateType } from "../../__generated__/schemaV3";
-import { SchemaId, OpenAttestationVerifiableCredential } from "../../shared/@types/document";
+
+const sampleDoc: OpenAttestationCredential = {
+  "@context": ["https://www.w3.org/2018/credentials/v1", "https://www.w3.org/2018/credentials/examples/v1"],
+  id: "http://example.edu/credentials/58473",
+  type: ["VerifiableCredential", "AlumniCredential"],
+  issuer: "https://example.edu/issuers/14",
+  issuanceDate: "2010-01-01T19:23:24Z",
+  credentialSubject: {
+    id: "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    alumniOf: "Example University"
+  },
+  template: {
+    name: "EXAMPLE_RENDERER",
+    type: TemplateType.EmbeddedRenderer,
+    url: "https://renderer.openattestation.com/"
+  },
+  oaProof: {
+    type: OaProofType.OpenAttestationProofMethod,
+    method: Method.DocumentStore,
+    value: "0xED2E50434Ac3623bAD763a35213DAD79b43208E4"
+  }
+};
 
 describe("digest v3.0", () => {
-  describe("placeholder for future tests", () => {
+  describe("digestDocument", () => {
     test("digests a document with all visible content correctly", () => {
-      // TODO: fix this
-      // it's not correct
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
-      const document: OpenAttestationVerifiableCredential = {
-        version: SchemaId.v3,
-        "@context": ["https://www.w3.org/2018/credentials/v1", "https://www.w3.org/2018/credentials/examples/v1"],
-        id: "http://example.edu/credentials/58473",
-        type: ["VerifiableCredential", "AlumniCredential"],
-        issuer: "https://example.edu/issuers/14",
-        issuanceDate: "2010-01-01T19:23:24Z",
-        credentialSubject: {
-          id: "did:example:ebfeb1f712ebc6f1c276e12ec21",
-          alumniOf: "Example University"
-        },
-        template: {
-          name: "EXAMPLE_RENDERER",
-          type: TemplateType.EmbeddedRenderer,
-          url: "https://renderer.openattestation.com/"
-        },
-        oaProof: {
-          type: OaProofType.OpenAttestationProofMethod,
-          method: Method.DocumentStore,
-          value: ""
-        }
-      };
+      const document = cloneDeep(sampleDoc);
 
-      const salts = salt(document);
+      // We shouldn't use const salts = salt(document); here as it's non-deterministic
+      const salts = [
+        { value: "dcc8c555-017d-433e-8a72-8b985e4b5fa8", path: "@context[0]" },
+        { value: "f24b43bf-8262-4d93-af69-3c059bb00f6a", path: "@context[1]" },
+        { value: "ade3ccd1-32ec-4f97-9635-b53dec282c8b", path: "id" },
+        { value: "d3ec986c-2dd7-4c8a-be46-7c77c958f825", path: "type[0]" },
+        { value: "ae4bdeaf-9d96-40ae-8ac7-15cd85e6c62c", path: "type[1]" },
+        { value: "8f4be04a-98af-4439-9c87-10fbf3e4c270", path: "issuer" },
+        { value: "05657d2e-aa0a-4869-8227-780cb52fb56a", path: "issuanceDate" },
+        { value: "bb8169f7-7562-46ee-9219-3b871943ea03", path: "credentialSubject.id" },
+        { value: "7773bc06-7187-4cc5-a3ba-87eed615718a", path: "credentialSubject.alumniOf" },
+        { value: "aee0854b-8c4b-4673-aba9-d98f655b9a20", path: "template.name" },
+        { value: "a418299a-571b-425c-8f82-e9f874fa6a10", path: "template.type" },
+        { value: "fd131c95-1c3b-490c-87cc-585efa2882c7", path: "template.url" },
+        { value: "b730ce97-cd3a-4bad-8802-13b5d8e2d27f", path: "oaProof.type" },
+        { value: "10978571-432e-4b5b-90c0-8f976a4de712", path: "oaProof.method" },
+        { value: "0934ec15-452d-420a-95e3-aa33ad6b417d", path: "oaProof.value" }
+      ];
       const digest = digestDocument(document, salts, []);
-      expect(digest).toBeTruthy();
+      const expectedDigest = "100ffe750d2ac887d9c4def00849dc7c08b21bba4a351883a6fc57b8c12d7474";
+      expect(digest).toEqual(expectedDigest);
+    });
+    test("handles shadowed keys correctly", () => {
+      const document = { ...cloneDeep(sampleDoc), "oaProof.value": "0xSomeMaliciousDocumentStore" };
+      expect(() => {
+        salt(document);
+      }).toThrow("Key names must not have . in them");
+    });
+    test("handles shadowed keys correctly (nested)", () => {
+      const document = { ...cloneDeep(sampleDoc), nested: { "oaProof.value": "0xSomeMaliciousDocumentStore" } };
+      expect(() => {
+        salt(document);
+      }).toThrow("Key names must not have . in them");
+    });
+    test("handles shadowed keys correctly (array)", () => {
+      const document = { ...cloneDeep(sampleDoc), "type[1]": "MaliciousCredential" };
+      expect(() => {
+        salt(document);
+      }).toThrow("Key names must not have '[' or ']' in them");
+    });
+    test("handles shadowed keys correctly (nested array)", () => {
+      const document = { ...cloneDeep(sampleDoc), nested: { "type[1]": "hmm" } };
+      expect(() => {
+        salt(document);
+      }).toThrow("Key names must not have '[' or ']' in them");
     });
   });
 });

--- a/src/v3/digest/digest.test.ts
+++ b/src/v3/digest/digest.test.ts
@@ -30,7 +30,7 @@ describe("digest v3.0", () => {
     test("digests a document with all visible content correctly", () => {
       const document = cloneDeep(sampleDoc);
 
-      // We shouldn't use const salts = salt(document); here as it's non-deterministic
+      // We shouldn't use create salts on every test here as it's non-deterministic
       const salts = [
         { value: "dcc8c555-017d-433e-8a72-8b985e4b5fa8", path: "@context[0]" },
         { value: "f24b43bf-8262-4d93-af69-3c059bb00f6a", path: "@context[1]" },
@@ -118,12 +118,10 @@ describe("digest v3.0", () => {
         ...cloneDeep(sampleDoc),
         grades: null
       };
-      expect(() => {
-        salt(document);
-      }).toThrow("Cannot convert undefined or null to object");
+      const salted = salt(document);
+      expect(salted).toContainEqual(expect.objectContaining({ path: "grades" }));
     });
     test("handles undefined values correctly", () => {
-      // TODO: check on how we handle undefined vs. null
       const document = {
         ...cloneDeep(sampleDoc),
         grades: undefined
@@ -137,14 +135,26 @@ describe("digest v3.0", () => {
         ...cloneDeep(sampleDoc),
         grades: ["A+", 100, 50.28, true, "B+"]
       };
-      expect(salt(document)).toBeTruthy();
+      const salted = salt(document);
+      expect(salted).toContainEqual(expect.objectContaining({ path: "grades[0]" }));
+      expect(salted).toContainEqual(expect.objectContaining({ path: "grades[1]" }));
+      expect(salted).toContainEqual(expect.objectContaining({ path: "grades[2]" }));
+      expect(salted).toContainEqual(expect.objectContaining({ path: "grades[3]" }));
+      expect(salted).toContainEqual(expect.objectContaining({ path: "grades[4]" }));
     });
     test("handles sparse arrays correctly", () => {
       const document = {
         ...cloneDeep(sampleDoc),
         grades: ["A+", 100, , , , true, "B+"]
       };
-      expect(salt(document)).toBeTruthy();
+      const salted = salt(document);
+      expect(salted).toContainEqual(expect.objectContaining({ path: "grades[0]" }));
+      expect(salted).toContainEqual(expect.objectContaining({ path: "grades[1]" }));
+      expect(salted).toContainEqual(expect.objectContaining({ path: "grades[5]" }));
+      expect(salted).toContainEqual(expect.objectContaining({ path: "grades[6]" }));
+      expect(salted).not.toContainEqual(expect.objectContaining({ path: "grades[2]" }));
+      expect(salted).not.toContainEqual(expect.objectContaining({ path: "grades[3]" }));
+      expect(salted).not.toContainEqual(expect.objectContaining({ path: "grades[4]" }));
     });
   });
 });

--- a/src/v3/digest/digest.test.ts
+++ b/src/v3/digest/digest.test.ts
@@ -132,14 +132,19 @@ describe("digest v3.0", () => {
         salt(document);
       }).toThrow("Unexpected value 'undefined' in 'grades'"); // Cannot convert undefined or null to object?
     });
-    test("handles funny stuff correctly (TODO)", () => {
+    test("handles numbers and booleans correctly", () => {
       const document = {
         ...cloneDeep(sampleDoc),
-        grades: ["A+", 100, 50.28, undefined, "B+"]
+        grades: ["A+", 100, 50.28, true, "B+"]
       };
-      expect(() => {
-        salt(document);
-      }).toThrow("Unexpected value 'undefined' in 'grades[3]'");
+      expect(salt(document)).toBeTruthy();
+    });
+    test("handles sparse arrays correctly", () => {
+      const document = {
+        ...cloneDeep(sampleDoc),
+        grades: ["A+", 100, , , , true, "B+"]
+      };
+      expect(salt(document)).toBeTruthy();
     });
   });
 });

--- a/src/v3/schema/schema.test.ts
+++ b/src/v3/schema/schema.test.ts
@@ -145,8 +145,16 @@ describe("schema/v3.0", () => {
       const document = { ...cloneDeep(sampleDoc), reference: null };
       // @ts-expect-error reference cannot be undefined or null
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
-        "message",
-        "Cannot convert undefined or null to object"
+        "validationErrors",
+        [
+          {
+            dataPath: ".reference",
+            keyword: "type",
+            message: "should be string",
+            params: { type: "string" },
+            schemaPath: "#/properties/reference/type"
+          }
+        ]
       );
     });
   });
@@ -175,8 +183,16 @@ describe("schema/v3.0", () => {
       const document = { ...cloneDeep(sampleDoc), name: null };
       // @ts-expect-error name cannot be undefined or null
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
-        "message",
-        "Cannot convert undefined or null to object"
+        "validationErrors",
+        [
+          {
+            dataPath: ".name",
+            keyword: "type",
+            message: "should be string",
+            params: { type: "string" },
+            schemaPath: "#/properties/name/type"
+          }
+        ]
       );
     });
   });
@@ -187,8 +203,34 @@ describe("schema/v3.0", () => {
       const document = { ...cloneDeep(sampleDoc), type: null };
       // @ts-expect-error type cannot be undefined or null
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
-        "message",
-        "Cannot convert undefined or null to object"
+        "validationErrors",
+        [
+          {
+            dataPath: ".type",
+            keyword: "type",
+            message: "should be array",
+            params: { type: "array" },
+            schemaPath: "#/definitions/type/oneOf/0/type"
+          },
+          {
+            dataPath: ".type",
+            keyword: "type",
+            message: "should be string",
+            params: {
+              type: "string"
+            },
+            schemaPath: "#/definitions/type/oneOf/1/type"
+          },
+          {
+            dataPath: ".type",
+            keyword: "oneOf",
+            message: "should match exactly one schema in oneOf",
+            params: {
+              passingSchemas: null
+            },
+            schemaPath: "#/definitions/type/oneOf"
+          }
+        ]
       );
     });
     it("should be invalid if type is a string", async () => {
@@ -234,8 +276,16 @@ describe("schema/v3.0", () => {
       const document = { ...cloneDeep(sampleDoc), validFrom: null };
       // @ts-expect-error validFrom cannot be undefined or null
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
-        "message",
-        "Cannot convert undefined or null to object"
+        "validationErrors",
+        [
+          {
+            dataPath: ".validFrom",
+            keyword: "type",
+            message: "should be string",
+            params: { type: "string" },
+            schemaPath: "#/properties/validFrom/type"
+          }
+        ]
       );
     });
 
@@ -281,8 +331,16 @@ describe("schema/v3.0", () => {
       const document = { ...cloneDeep(sampleDoc), validUntil: null };
       // @ts-expect-error validUntil cannot be undefined or null
       await expect(wrapDocument(document, { externalSchemaId: $id, version: SchemaId.v3 })).rejects.toHaveProperty(
-        "message",
-        "Cannot convert undefined or null to object"
+        "validationErrors",
+        [
+          {
+            dataPath: ".validUntil",
+            keyword: "type",
+            message: "should be string",
+            params: { type: "string" },
+            schemaPath: "#/properties/validUntil/type"
+          }
+        ]
       );
     });
     it("should be invalid if validUntil exists and is not in the RFC3339 date and time format", async () => {

--- a/src/v3/wrap.ts
+++ b/src/v3/wrap.ts
@@ -13,10 +13,10 @@ const deepMap = (value: any, path: string): Salt[] => {
   if (Array.isArray(value)) {
     return value.flatMap((v, index) => deepMap(v, `${path}[${index}]`));
   }
-  if (typeof value === "object") {
+  if (typeof value === "object" && value) {
     return Object.keys(value).flatMap(key => deepMap(value[key], path ? `${path}.${key}` : key));
   }
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean" || value === null) {
     return [{ value: uuid(), path }];
   }
   throw new Error(`Unexpected value '${value}' in '${path}'`);

--- a/src/v3/wrap.ts
+++ b/src/v3/wrap.ts
@@ -13,6 +13,7 @@ const deepMap = (value: any, path: string): Salt[] => {
   if (Array.isArray(value)) {
     return value.flatMap((v, index) => deepMap(v, `${path}[${index}]`));
   }
+  // Since null values are allowed but typeof null === "object", the "&& value" is used to skip this
   if (typeof value === "object" && value) {
     return Object.keys(value).flatMap(key => deepMap(value[key], path ? `${path}.${key}` : key));
   }

--- a/src/v3/wrap.ts
+++ b/src/v3/wrap.ts
@@ -14,13 +14,7 @@ const deepMap = (value: any, path: string): Salt[] => {
     return value.flatMap((v, index) => deepMap(v, `${path}[${index}]`));
   }
   if (typeof value === "object") {
-    return Object.keys(value).flatMap(key => {
-      // TODO: Feels weird... cos deepMap itself is recursive. Need to check on this again
-      // if (path.includes(".")) {
-      //   throw new Error("Key names must not have . in them");
-      // }
-      return deepMap(value[key], path ? `${path}.${key}` : key);
-    });
+    return Object.keys(value).flatMap(key => deepMap(value[key], path ? `${path}.${key}` : key));
   }
   if (typeof value === "string") {
     return [{ value: uuid(), path }];
@@ -37,7 +31,7 @@ const illegalCharactersCheck = (data: object) => {
       throw new Error("Key names must not have '[' or ']' in them");
     }
     if (value && typeof value === "object") {
-      return illegalCharactersCheck(value);
+      return illegalCharactersCheck(value); // Recursively search if property contains sub-properties
     }
   });
 };

--- a/src/v3/wrap.ts
+++ b/src/v3/wrap.ts
@@ -16,7 +16,7 @@ const deepMap = (value: any, path: string): Salt[] => {
   if (typeof value === "object") {
     return Object.keys(value).flatMap(key => deepMap(value[key], path ? `${path}.${key}` : key));
   }
-  if (typeof value === "string") {
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
     return [{ value: uuid(), path }];
   }
   throw new Error(`Unexpected value '${value}' in '${path}'`);


### PR DESCRIPTION
For the digest process:

- Added `illegalCharactersCheck`, to be done before `salt`ing the document
  - Checks for `.`, `[` and `]` to prevent such characters from being salted since they would cause shadowed keys
  - I didn't put the checks inside `salt` due to how `${path}.${key}` is being recursively passed into `deepMap`
- Fixed the supposed non-deterministic salts, changed it to using hardcoded salts
- Added `number` and `boolean` as allowed data types, and `null` is accepted now
  - Allowed data types are: `object, array, string, number, boolean` and values: `null`, everything else is rejected
- Improved test cases expected values

For schema:

- Since `null` is accepted, changed some test cases expected values (should now be expecting schema validation errors)

Also added test case coverage for:

- shadowed keys (arrays and objects)
- null and undefined values in document
- sparse arrays