### PR TITLE
feat: allowing any types of attachment

### DIFF
--- a/src/schema/2.0/sample-document.json
+++ b/src/schema/2.0/sample-document.json
@@ -24,6 +24,11 @@
       "filename": "sample.pdf",
       "type": "application/pdf",
       "data": "BASE64_ENCODED_FILE"
+    },
+    {
+      "filename": "sample.opencert",
+      "type": "application/octet-stream",
+      "data": "BASE64_ENCODED_FILE"
     }
   ]
 }

--- a/src/schema/2.0/schema.json
+++ b/src/schema/2.0/schema.json
@@ -176,8 +176,7 @@
           },
           "type": {
             "type": "string",
-            "description": "Type of attachment",
-            "enum": ["application/pdf", "image/png", "image/jpeg", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"]
+            "description": "Type of attachment"
           },
           "data": {
             "type": "string",

--- a/src/schema/2.0/schema.test.ts
+++ b/src/schema/2.0/schema.test.ts
@@ -397,42 +397,7 @@ describe("schema/v2.0", () => {
       const wrappedDocument = wrapDocument(omit(cloneDeep(sampleDoc), "attachments"));
       expect(wrappedDocument.version).toBe(SchemaId.v2);
     });
-    it("should not be valid with invalid file type", () => {
-      expect.assertions(2);
 
-      const document = {
-        ...sampleDoc,
-        attachments: [
-          {
-            filename: "sample.aac",
-            type: "audio/aac",
-            data: "BASE64_ENCODED_FILE"
-          }
-        ]
-      };
-      try {
-        wrapDocument(document);
-      } catch (e) {
-        expect(e).toHaveProperty("message", "Invalid document");
-        expect(e).toHaveProperty("validationErrors", [
-          {
-            dataPath: ".attachments[0].type",
-            keyword: "enum",
-            message: "should be equal to one of the allowed values",
-            params: {
-              allowedValues: [
-                "application/pdf",
-                "image/png",
-                "image/jpeg",
-                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-              ]
-            },
-            schemaPath: "#/properties/attachments/items/properties/type/enum"
-          }
-        ]);
-      }
-    });
     it("should not be valid without attachments filename", () => {
       expect.assertions(2);
 


### PR DESCRIPTION
## Allowing all attachment types in the base layer

There is a problem attaching files like `.tt` or `.opencert` which gets read as `data:application/octet-stream;base64,ewogICJzY2hlb` with `application/octet-stream` as the type. So... you cannot attach a .tt or .opencert file.

Also, zip files are excluded now. This PR will make the scheme less opinionated. 