### PR TITLE
fixL scoped context under OpenAttestationCredential

### DIFF
--- a/src/3.0/context/context.jsonld
+++ b/src/3.0/context/context.jsonld
@@ -2,69 +2,74 @@
   "@context": {
     "@version": 1.1,
     "@protected": true,
-    "identity": {
-      "@id": "https://lol.com/todo",
+    "OpenAttestationCredential": {
+      "@id": "https://schemata.openattestation.com/vocab/#OpenAttestationCredential",
       "@context": {
-        "@version": 1.1,
-        "@protected": true,
-        "id": "@id",
-        "type": "@type",
-        "identifier": "xsd:string",
-        "DNS-TXT": "xsd:string"
-      }
-    },
-    "template": {
-      "@id": "https://lol.com/todo",
-      "@context": {
-        "@version": 1.1,
-        "@protected": true,
-        "id": "@id",
-        "type": "@type",
+        "identity": {
+          "@id": "https://lol.com/todo",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "identifier": "xsd:string",
+            "DNS-TXT": "xsd:string"
+          }
+        },
+        "template": {
+          "@id": "https://lol.com/todo",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "name": "xsd:string",
+            "url": "xsd:string",
+            "EMBEDDED_RENDERER": "xsd:string"
+          }
+        },
+        "privacy": {
+          "@id": "https://lol.com/todo",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "obfuscatedData": {
+              "@id": "https://lol.com/todo",
+              "@container": [
+                "@index",
+                "@set"
+              ]
+            }
+          }
+        },
+        "method": "xsd:string",
+        "OpenAttestationSignature2018": "xsd:string",
+        "reference": "xsd:string",
         "name": "xsd:string",
-        "url": "xsd:string",
-        "EMBEDDED_RENDERER": "xsd:string"
-      }
-    },
-    "privacy": {
-      "@id": "https://lol.com/todo",
-      "@context": {
-        "@version": 1.1,
-        "@protected": true,
-        "obfuscatedData": {
+        "value": "xsd:string",
+        "path": "xsd:string",
+        "signature": {
           "@id": "https://lol.com/todo",
-          "@container": [
-            "@index",
-            "@set"
-          ]
-        }
+          "@context": {
+            "@version": 1.1,
+            "id": "@id",
+            "@protected": true,
+            "targetHash": "xsd:string",
+            "proof": "xsd:string",
+            "merkleRoot": "xsd:string",
+            "salts": {
+              "@id": "https://lol.com/todo",
+              "@container": [
+                "@index",
+                "@set"
+              ]
+            }
+          }
+        },
+        "data": "xsd:string",
+        "fileName": "xsd:string",
+        "mimeType": "xsd:string"
       }
-    },
-    "method": "xsd:string",
-    "OpenAttestationSignature2018": "xsd:string",
-    "reference": "xsd:string",
-    "name": "xsd:string",
-    "value": "xsd:string",
-    "path": "xsd:string",
-    "signature": {
-      "@id": "https://lol.com/todo",
-      "@context": {
-        "@version": 1.1,
-        "id": "@id",
-        "@protected": true,
-        "targetHash": "xsd:string",
-        "proof": "xsd:string",
-        "merkleRoot": "xsd:string",
-        "salts": {
-          "@id": "https://lol.com/todo",
-          "@container": [
-            "@index",
-            "@set"
-          ]
-        }
-      }
-    },
-    "data": "xsd:string",
-    "fileName": "xsd:string",
-    "mimeType": "xsd:string"
+    }
   }
 }


### PR DESCRIPTION
This PR proposes a way to fix #183. I have introduced new more specific credential type - `OpenAttestationCredential`, and this context only applies to the credential which has this type assigned. So that the credential issuer can override the vocabulary for terms under the `credentialSubject`.