### PR TITLE
Feat/add guard and utils

### DIFF
--- a/src/shared/utils/@types/diagnose.ts
+++ b/src/shared/utils/@types/diagnose.ts
@@ -1,0 +1,2 @@
+export type Kind = "raw" | "wrapped" | "signed";
+export type Mode = "strict" | "non-strict";

--- a/src/shared/utils/__tests__/diagnose.test.ts
+++ b/src/shared/utils/__tests__/diagnose.test.ts
@@ -14,7 +14,53 @@ import { omit } from "lodash";
 describe("diagnose", () => {
   let wrappedV3Document: WrappedDocument<v3.OpenAttestationDocument>;
   let signedV2Document: v2.SignedWrappedDocument;
-  const wrappedV2Document: WrappedDocument<v2.OpenAttestationDocument> = wrapDocument({
+
+  const rawV3Document: v3.OpenAttestationDocument = {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1",
+      "https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json",
+    ],
+    issuer: {
+      name: "name",
+      id: "https://example.com",
+    },
+    issuanceDate: "2010-01-01T19:23:24Z",
+    type: ["VerifiableCredential", "UniversityDegreeCredential", "OpenAttestationCredential"],
+    credentialSubject: {
+      id: "did:example:ebfeb1f712ebc6f1c276e12ec21",
+      degree: {
+        type: "BachelorDegree",
+        name: "Bachelor of Science and Arts",
+      },
+    },
+    openAttestationMetadata: {
+      proof: {
+        value: "0xabcf",
+        type: v3.ProofType.OpenAttestationProofMethod,
+        method: v3.Method.DocumentStore,
+      },
+      template: {
+        url: "https://",
+        name: "",
+        type: v3.TemplateType.EmbeddedRenderer,
+      },
+      identityProof: {
+        identifier: "whatever",
+        type: v2.IdentityProofType.DNSTxt,
+      },
+    },
+    name: "",
+    reference: "",
+    validFrom: "2010-01-01T19:23:24Z",
+  };
+
+  const rawV2Document: v2.OpenAttestationDocument = {
+    $template: {
+      name: "main",
+      type: v2.TemplateType.EmbeddedRenderer,
+      url: "https://tutorial-renderer.openattestation.com",
+    },
     issuers: [
       {
         name: "John",
@@ -25,56 +71,21 @@ describe("diagnose", () => {
         },
       },
     ],
-  });
+  };
+
+  const wrappedV2Document: WrappedDocument<v2.OpenAttestationDocument> = wrapDocument(rawV2Document);
+
   beforeAll(async () => {
-    wrappedV3Document = await __unsafe__use__it__at__your__own__risks__wrapDocument(
-      {
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://www.w3.org/2018/credentials/examples/v1",
-          "https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json",
-        ],
-        issuer: {
-          name: "name",
-          type: "OpenAttestationIssuer",
-          id: "https://example.com",
-        },
-        issuanceDate: "2010-01-01T19:23:24Z",
-        type: ["VerifiableCredential", "UniversityDegreeCredential", "OpenAttestationCredential"],
-        credentialSubject: {
-          id: "did:example:ebfeb1f712ebc6f1c276e12ec21",
-          degree: {
-            type: "BachelorDegree",
-            name: "Bachelor of Science and Arts",
-          },
-        },
-        openAttestationMetadata: {
-          proof: {
-            value: "0xabcf",
-            type: v3.ProofType.OpenAttestationProofMethod,
-            method: v3.Method.DocumentStore,
-          },
-          template: {
-            url: "https://",
-            name: "",
-            type: v3.TemplateType.EmbeddedRenderer,
-          },
-          identityProof: {
-            identifier: "whatever",
-            type: v2.IdentityProofType.DNSTxt,
-          },
-        },
-        name: "",
-        reference: "",
-        validFrom: "2010-01-01T19:23:24Z",
-      },
-      { version: SchemaId.v3 }
-    );
+    wrappedV3Document = await __unsafe__use__it__at__your__own__risks__wrapDocument(rawV3Document, {
+      version: SchemaId.v3,
+    });
+
     signedV2Document = await signDocument(wrappedV2Document, SUPPORTED_SIGNING_ALGORITHM.Secp256k1VerificationKey2018, {
       public: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
       private: "0x497c85ed89f1874ba37532d1e33519aba15bd533cdcb90774cc497bfe3cde655",
     });
   });
+
   describe("3.0", () => {
     it("should return an error when document is empty", () => {
       expect(diagnose({ version: "3.0", kind: "wrapped", document: null, mode: "non-strict" })).toMatchInlineSnapshot(`
@@ -85,11 +96,13 @@ describe("diagnose", () => {
         ]
       `);
     });
+
     it("should not return an error when document is valid", () => {
       expect(
         diagnose({ version: "3.0", kind: "wrapped", document: wrappedV3Document, mode: "non-strict" })
       ).toMatchInlineSnapshot(`Array []`);
     });
+
     it("should return an error when document does not have issuer", () => {
       expect(
         diagnose({ version: "3.0", kind: "wrapped", document: omit(wrappedV3Document, "issuer"), mode: "non-strict" })
@@ -104,7 +117,25 @@ describe("diagnose", () => {
         ]
       `);
     });
+
+    it("should return an error when raw document is not version 3", () => {
+      expect(diagnose({ version: "3.0", kind: "raw", document: rawV2Document, mode: "non-strict" }))
+        .toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "message": "The raw document does not match OpenAttestation schema 3.0",
+          },
+        ]
+      `);
+    });
+
+    it("should not return an error when raw document is version 3", () => {
+      expect(
+        diagnose({ version: "3.0", kind: "raw", document: rawV3Document, mode: "non-strict" })
+      ).toMatchInlineSnapshot(`Array []`);
+    });
   });
+
   describe("2.0", () => {
     it("should return an error when document is empty", () => {
       expect(diagnose({ version: "2.0", kind: "wrapped", document: null, mode: "non-strict" })).toMatchInlineSnapshot(`
@@ -115,11 +146,13 @@ describe("diagnose", () => {
         ]
       `);
     });
+
     it("should not return an error when document is valid", () => {
       expect(
         diagnose({ version: "2.0", kind: "signed", document: signedV2Document, mode: "non-strict" })
       ).toMatchInlineSnapshot(`Array []`);
     });
+
     it("should return an error when document does not have issuer", () => {
       expect(
         diagnose({
@@ -138,6 +171,23 @@ describe("diagnose", () => {
           },
         ]
       `);
+    });
+
+    it("should return an error when raw document is not version 2", () => {
+      expect(diagnose({ version: "2.0", kind: "raw", document: rawV3Document, mode: "non-strict" }))
+        .toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "message": "The raw document does not match OpenAttestation schema 2.0",
+          },
+        ]
+      `);
+    });
+
+    it("should not return an error when raw document is version 2", () => {
+      expect(
+        diagnose({ version: "2.0", kind: "raw", document: rawV2Document, mode: "non-strict" })
+      ).toMatchInlineSnapshot(`Array []`);
     });
   });
 });

--- a/src/shared/utils/__tests__/diagnose.test.ts
+++ b/src/shared/utils/__tests__/diagnose.test.ts
@@ -123,7 +123,25 @@ describe("diagnose", () => {
         .toMatchInlineSnapshot(`
         Array [
           Object {
-            "message": "The raw document does not match OpenAttestation schema 3.0",
+            "message": "The document does not match OpenAttestation schema 3.0",
+          },
+          Object {
+            "message": "document - must have required property '@context'",
+          },
+          Object {
+            "message": "document - must have required property 'type'",
+          },
+          Object {
+            "message": "document - must have required property 'credentialSubject'",
+          },
+          Object {
+            "message": "document - must have required property 'issuer'",
+          },
+          Object {
+            "message": "document - must have required property 'issuanceDate'",
+          },
+          Object {
+            "message": "document - must have required property 'openAttestationMetadata'",
           },
         ]
       `);
@@ -178,7 +196,10 @@ describe("diagnose", () => {
         .toMatchInlineSnapshot(`
         Array [
           Object {
-            "message": "The raw document does not match OpenAttestation schema 2.0",
+            "message": "The document does not match OpenAttestation schema 2.0",
+          },
+          Object {
+            "message": "document - must have required property 'issuers'",
           },
         ]
       `);
@@ -188,6 +209,7 @@ describe("diagnose", () => {
       expect(
         diagnose({ version: "2.0", kind: "raw", document: rawV2Document, mode: "non-strict" })
       ).toMatchInlineSnapshot(`Array []`);
+      console.log(diagnose({ version: "2.0", kind: "raw", document: rawV2Document, mode: "non-strict" }));
     });
   });
 });

--- a/src/shared/utils/__tests__/utils.test.ts
+++ b/src/shared/utils/__tests__/utils.test.ts
@@ -3,6 +3,8 @@ import { wrapDocument } from "../../..";
 import { WrappedDocument } from "../../../shared/@types/document";
 import * as v2 from "../../../__generated__/schema.2.0";
 import * as v3 from "../../../__generated__/schema.3.0";
+import * as v2RawDocument from "../../../../test/fixtures/v2/raw-document.json";
+import * as v3RawDocument from "../../../../test/fixtures/v3/raw-document.json";
 import * as v2WrappedVerifiableDocument from "../../../../test/fixtures/v2/not-obfuscated-wrapped.json";
 import * as v3WrappedVerifiableDocument from "../../../../test/fixtures/v3/not-obfuscated-wrapped.json";
 import * as v2WrappedDidDocument from "../../../../test/fixtures/v2/did-wrapped.json";
@@ -246,6 +248,38 @@ describe("Util Functions", () => {
     test("should return error when v2 document doesn't have token registry", async () => {
       expect(() => utils.getAssetId(v2WrappedVerifiableDocument)).toThrow(
         "Unsupported document type: Only can retrieve asset id from wrapped OpenAttestation v2 & v3 transferable documents."
+      );
+    });
+  });
+
+  describe("getTemplateURL", () => {
+    test("should return template url for raw v2 document", async () => {
+      expect(utils.getTemplateURL(v2RawDocument)).toStrictEqual("https://tutorial-renderer.openattestation.com");
+    });
+    test("should return template url for wrapped v2 document", async () => {
+      expect(utils.getTemplateURL(v2WrappedVerifiableDocument)).toStrictEqual(
+        "https://tutorial-renderer.openattestation.com"
+      );
+    });
+    test("should return template url for raw v3 document", async () => {
+      expect(utils.getTemplateURL(v3RawDocument)).toStrictEqual("https://tutorial-renderer.openattestation.com");
+    });
+    test("should return template url for wrapped v3 document", async () => {
+      expect(utils.getTemplateURL(v3WrappedVerifiableDocument)).toStrictEqual(
+        "https://tutorial-renderer.openattestation.com"
+      );
+    });
+    test("should return error when document is not OpenAttestation document", async () => {
+      const document: WrappedDocument<any> = {
+        signature: {
+          type: "SHA3MerkleProof",
+          targetHash: "c5d53262962b192c5c977f2252acd4862f41cc1ccce7e87c5b406905a2726692",
+          proof: [],
+          merkleRoot: "c5d53262962b192c5c977f2252acd4862f41cc1ccce7e87c5b406905a2726692",
+        },
+      };
+      expect(() => utils.getTemplateURL(document)).toThrow(
+        new Error("Unsupported document type: Only can retrieve template url from OpenAttestation v2 & v3 documents.")
       );
     });
   });

--- a/src/shared/utils/diagnose.ts
+++ b/src/shared/utils/diagnose.ts
@@ -9,10 +9,9 @@ import {
 import { ArrayProof, Signature, SignatureStrict } from "../../2.0/types";
 import { clone, cloneDeepWith } from "lodash";
 import { buildAjv, getSchema } from "../ajv";
+import { Kind, Mode } from "./@types/diagnose";
 
 type Version = "2.0" | "3.0";
-export type Kind = "raw" | "wrapped" | "signed";
-export type Mode = "strict" | "non-strict";
 
 interface DiagnoseError {
   message: string;

--- a/src/shared/utils/diagnose.ts
+++ b/src/shared/utils/diagnose.ts
@@ -11,7 +11,7 @@ import { clone, cloneDeepWith } from "lodash";
 import { buildAjv, getSchema } from "../ajv";
 
 type Version = "2.0" | "3.0";
-type Kind = "raw" | "wrapped" | "signed";
+export type Kind = "raw" | "wrapped" | "signed";
 export type Mode = "strict" | "non-strict";
 
 interface DiagnoseError {
@@ -85,19 +85,10 @@ export const diagnose = ({
     return handleError(debug, "The document must be an object");
   }
 
-  if (kind === "raw") {
-    if (version === "2.0") {
-      return document.$template ? [] : handleError(debug, `The raw document does not match OpenAttestation schema 2.0`);
-    } else {
-      return document["@context"]
-        ? []
-        : handleError(debug, `The raw document does not match OpenAttestation schema 3.0`);
-    }
-  }
-
   const errors = validate(
     document,
-    getSchema(version === "3.0" ? SchemaId.v3 : SchemaId.v2, mode === "non-strict" ? ajv : undefined)
+    getSchema(version === "3.0" ? SchemaId.v3 : SchemaId.v2, mode === "non-strict" ? ajv : undefined),
+    kind
   );
 
   if (errors.length > 0) {
@@ -107,6 +98,10 @@ export const diagnose = ({
       `The document does not match OpenAttestation schema ${version === "3.0" ? "3.0" : "2.0"}`,
       ...errors.map((error) => `${error.instancePath || "document"} - ${error.message}`)
     );
+  }
+
+  if (kind === "raw") {
+    return [];
   }
 
   if (version === "3.0") {

--- a/src/shared/utils/guard.ts
+++ b/src/shared/utils/guard.ts
@@ -7,7 +7,8 @@ import {
   OpenAttestationDocument as OpenAttestationDocumentV2,
   WrappedDocument as WrappedDocumentV2,
 } from "../../2.0/types";
-import { diagnose, Mode } from "./diagnose";
+import { diagnose } from "./diagnose";
+import { Mode } from "./@types/diagnose";
 
 /**
  *

--- a/src/shared/utils/guard.ts
+++ b/src/shared/utils/guard.ts
@@ -14,6 +14,30 @@ import { diagnose, Mode } from "./diagnose";
  * @param document
  * @param mode strict or non-strict. Strict will perform additional check on the data. For instance strict validation will ensure that a target hash is a 32 bytes hex string while non strict validation will just check that target hash is a string.
  */
+export const isRawV2Document = (
+  document: any,
+  { mode }: { mode: Mode } = { mode: "non-strict" }
+): document is OpenAttestationDocumentV2 => {
+  return diagnose({ version: "2.0", kind: "raw", document, debug: false, mode }).length === 0;
+};
+
+/**
+ *
+ * @param document
+ * @param mode strict or non-strict. Strict will perform additional check on the data. For instance strict validation will ensure that a target hash is a 32 bytes hex string while non strict validation will just check that target hash is a string.
+ */
+export const isRawV3Document = (
+  document: any,
+  { mode }: { mode: Mode } = { mode: "non-strict" }
+): document is OpenAttestationDocumentV3 => {
+  return diagnose({ version: "3.0", kind: "raw", document, debug: false, mode }).length === 0;
+};
+
+/**
+ *
+ * @param document
+ * @param mode strict or non-strict. Strict will perform additional check on the data. For instance strict validation will ensure that a target hash is a 32 bytes hex string while non strict validation will just check that target hash is a string.
+ */
 export const isWrappedV3Document = (
   document: any,
   { mode }: { mode: Mode } = { mode: "non-strict" }

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -1,11 +1,11 @@
 import { keccak256 } from "js-sha3";
-import { OpenAttestationDocument as OpenAttestationDocumentV2 } from "../../__generated__/schema.2.0";
+import { OpenAttestationDocument as OpenAttestationDocumentV2, TemplateObject } from "../../__generated__/schema.2.0";
 import { OpenAttestationDocument as OpenAttestationDocumentV3 } from "../../__generated__/schema.3.0";
 import { WrappedDocument as WrappedDocumentV2 } from "../../2.0/types";
 import { WrappedDocument as WrappedDocumentV3 } from "../../3.0/types";
 import { unsaltData } from "../../2.0/salt";
 import { ErrorObject } from "ajv";
-import { isWrappedV2Document, isWrappedV3Document } from "./guard";
+import { isRawV2Document, isRawV3Document, isWrappedV2Document, isWrappedV3Document } from "./guard";
 
 export type Hash = string | Buffer;
 type Extract<P> = P extends WrappedDocumentV2<infer T> ? T : never;
@@ -101,6 +101,22 @@ export const getTargetHash = (document: any): string => {
     default:
       throw new Error(
         "Unsupported document type: Only can retrieve target hash from wrapped OpenAttestation v2 & v3 documents."
+      );
+  }
+};
+
+// get template url from raw document for document renderer preview.
+export const getTemplateURL = (document: any): string | undefined => {
+  switch (true) {
+    case isWrappedV2Document(document):
+      return (getData(document).$template as TemplateObject).url;
+    case isRawV2Document(document):
+      return document.$template.url;
+    case isRawV3Document(document) || isWrappedV3Document(document):
+      return document.openAttestationMetadata.template.url;
+    default:
+      throw new Error(
+        "Unsupported document type: Only can retrieve template url from OpenAttestation v2 & v3 documents."
       );
   }
 };

--- a/src/shared/validate/validate.ts
+++ b/src/shared/validate/validate.ts
@@ -7,7 +7,7 @@ import { Kind } from "../utils/diagnose";
 
 const logger = getLogger("validate");
 
-export const validateSchema = (document: any, validator: ValidateFunction, kind: Kind): ErrorObject[] => {
+export const validateSchema = (document: any, validator: ValidateFunction, kind?: Kind): ErrorObject[] => {
   if (!validator) {
     throw new Error("No schema validator provided");
   }

--- a/src/shared/validate/validate.ts
+++ b/src/shared/validate/validate.ts
@@ -3,8 +3,7 @@ import { getLogger } from "../logger";
 import { SchemaId } from "../@types/document";
 // don't change this otherwise there is a cycle
 import { getData } from "../utils/utils";
-import { Kind } from "../utils/diagnose";
-
+import { Kind } from "../utils/@types/diagnose";
 const logger = getLogger("validate");
 
 export const validateSchema = (document: any, validator: ValidateFunction, kind?: Kind): ErrorObject[] => {

--- a/src/shared/validate/validate.ts
+++ b/src/shared/validate/validate.ts
@@ -3,14 +3,17 @@ import { getLogger } from "../logger";
 import { SchemaId } from "../@types/document";
 // don't change this otherwise there is a cycle
 import { getData } from "../utils/utils";
+import { Kind } from "../utils/diagnose";
 
 const logger = getLogger("validate");
 
-export const validateSchema = (document: any, validator: ValidateFunction): ErrorObject[] => {
+export const validateSchema = (document: any, validator: ValidateFunction, kind: Kind): ErrorObject[] => {
   if (!validator) {
     throw new Error("No schema validator provided");
   }
-  const valid = validator(document.version === SchemaId.v3 ? document : getData(document));
+
+  const valid = validator(document.version === SchemaId.v3 || kind === "raw" ? document : getData(document));
+
   if (!valid) {
     logger.debug(`There are errors in the document: ${JSON.stringify(validator.errors)}`);
     return validator.errors ?? [];

--- a/test/fixtures/v2/raw-document.json
+++ b/test/fixtures/v2/raw-document.json
@@ -1,0 +1,20 @@
+{
+  "$template": {
+    "name": "main",
+    "type": "EMBEDDED_RENDERER",
+    "url": "https://tutorial-renderer.openattestation.com"
+  },
+  "recipient": {
+    "name": "John Doe"
+  },
+  "issuers": [
+    {
+      "name": "Demo Issuer",
+      "documentStore": "0xBBb55Bd1D709955241CAaCb327A765e2b6D69c8b",
+      "identityProof": {
+        "type": "DNS-TXT",
+        "location": "few-green-cat.sandbox.openattestation.com"
+      }
+    }
+  ]
+}

--- a/test/fixtures/v3/raw-document.json
+++ b/test/fixtures/v3/raw-document.json
@@ -1,0 +1,44 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://schemata.openattestation.com/com/openattestation/1.0/DrivingLicenceCredential.json",
+    "https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json",
+    "https://schemata.openattestation.com/com/openattestation/1.0/CustomContext.json"
+  ],
+  "reference": "SERIAL_NUMBER_123",
+  "name": "Republic of Singapore Driving Licence",
+  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
+  "issuer": { "id": "https://example.com", "name": "DEMO STORE", "type": "OpenAttestationIssuer" },
+  "type": ["VerifiableCredential", "DrivingLicenceCredential", "OpenAttestationCredential"],
+  "credentialSubject": {
+    "id": "did:example:JOHN_DOE_DID",
+    "licenseNumber": "S1234567a",
+    "birthDate": "1977-02-22",
+    "name": "John Doe",
+    "class": [
+      { "type": "3", "effectiveDate": "2010-01-01T19:23:24Z" },
+      { "type": "3A", "effectiveDate": "2010-01-01T19:23:24Z" }
+    ]
+  },
+  "openAttestationMetadata": {
+    "template": {
+      "name": "DRIVING_LICENSE",
+      "type": "EMBEDDED_RENDERER",
+      "url": "https://tutorial-renderer.openattestation.com"
+    },
+    "proof": {
+      "type": "OpenAttestationProofMethod",
+      "method": "DID",
+      "value": "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+      "revocation": {
+        "type": "NONE"
+      }
+    },
+    "identityProof": {
+      "type": "DNS-DID",
+      "identifier": "example.tradetrust.io"
+    }
+  },
+  "attachments": [{ "fileName": "sample.pdf", "mimeType": "application/pdf", "data": "BASE64_ENCODED_FILE" }]
+}


### PR DESCRIPTION
- added more guards to validate raw v2 and v3 documents.
This is used when it is required to determine which document uses the respective wrapping function.

- added util to get templateURL
As both schemas are different, I added util to return the template URL. This is used during document preview which happened before the wrapping process.