### PR TITLE
fix: 🐛 node version to lts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: 'circleci/node:latest'
+      - image: "circleci/node:lts"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
changed node version from node:latest to node:lts to fix [digital envelope](https://stackoverflow.com/questions/69692842/error0308010cdigital-envelope-routinesunsupported) bug