### PR TITLE
 docs: update README, remove incorrect v3 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 Attestation and notary framework for any document types on the blockchain.
 
-OpenAttestation allows any entity to proof the existence of a document or a batch of documents. It makes use of smart contracts on the Ethereum blockchain to store cryptographic proofs of individual documents.
+OpenAttestation allows any entity to prove the existence of a document or a batch of documents. It makes use of smart contracts on the Ethereum blockchain to store cryptographic proofs of individual documents.
+
+Alternatively, OpenAttestation can be used to make digitally verifiable documents using digital signatures, forgoing the need to pay for Ethereum transactions.
 
 The [Open Attestation](https://github.com/Open-Attestation/open-attestation) repository allows you to batch the documents to obtain the merkle root of the batch to be committed to the blockchain. It also allows you to verify the signature of the document wrapped using the OpenAttestation framework.
 
@@ -20,11 +22,11 @@ npm i @govtechsg/open-attestation
 
 ### Wrapping documents
 
-`wrapDocuments` takes in an array of document and returns the batched documents. Each document must be valid regarding the version of the schema used (see below) It computes the merkle root of the batch and appends the signature to each document. This merkle root can be published on the blockchain and queried against to prove the provenance of the document issued this way.
+`wrapDocuments` takes in an array of documents and returns the wrapped batch. Each document must be valid regarding the version of the schema used (see below) It computes the Merkle root of the batch and appends it to each document. This Merkle root can be published on the blockchain and queried against to prove the provenance of the document issued this way. Alternatively, the Merkle root may be signed by the document issuer's private key, which may be cryptographically verified using the issuer's public key or Ethereum account.
 
-This function accept a second optional parameter to specify the version of open-attestation you want to use. By default, open-attestation will use schema 2.0.
+In the future, this function may accept a second optional parameter to specify the version of open-attestation you want to use. Currently, open-attestation will use schema 2.0. See [Additional Information](#additional-information) for information on using experimental v3.0 documents, which aim to be compatible with the W3C's data model for [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/).
 
-The `wrapDocument` function is identical but accept only one document.
+The `wrapDocument` function is identical but accepts only one document.
 
 ```js
 import { wrapDocuments } from "@govtechsg/open-attestation";
@@ -60,8 +62,6 @@ const document = {
 
 wrappedDocuments = wrapDocuments([document, { ...document, id: "different id" }]); // will ensure document is valid regarding open-attestation 2.0 schema
 console.log(wrappedDocuments);
-wrappedDocuments = wrapDocuments([document, { ...document, id: "different id" }], { version: "open-attestation/3.0" }); // will ensure document is valid regarding open-attestation 3.0 schema
-console.log(wrappedDocuments);
 ```
 
 > Note:
@@ -77,7 +77,7 @@ console.log(wrappedDocuments);
 
 ### Sign a document
 
-`signDocument` takes a wrapped document, as well as a public/private key pair or an [Ethers.js Signer](https://docs.ethers.io/v5/api/signer/). The method will sign the merkle root from the wrapped document, happened the signature to the document and return it. Currently, it supports the following sign algorithm:
+`signDocument` takes a wrapped document, as well as a public/private key pair or an [Ethers.js Signer](https://docs.ethers.io/v5/api/signer/). The method will sign the merkle root from the wrapped document, appened the signature to the document and return it. Currently, it supports the following sign algorithm:
 
 - `Secp256k1VerificationKey2018`
 
@@ -192,6 +192,7 @@ You can now debug from the `vc-test-suite` folder the way you need it.
   - [OA schema v3](https://schema.openattestation.com/3.0/schema.json)
   - Typings: `import {v3} from "@govtechsg/open-attestation"`.
   - Type guard: `utils.isWrappedV3Document`.
-  - Wrapping: `wrapDocument(document, {version: "open-attestation/3.0"})`
-- There are extra utilities available:
+  - Wrapping: `__unsafe__use__it__at__your__own__risks__wrapDocument` (future usage: `wrapDocument(document, {version: "open-attestation/3.0"})`
+  - Example docs in `tests/fixtures/v3`
+- There are extra utilities available: 
   - Refer to the [utils](https://github.com/Open-Attestation/open-attestation/blob/master/src/shared/utils/utils.ts) component for the full list of utilities.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ console.log(wrappedDocuments);
 
 ### Sign a document
 
-`signDocument` takes a wrapped document, as well as a public/private key pair or an [Ethers.js Signer](https://docs.ethers.io/v5/api/signer/). The method will sign the merkle root from the wrapped document, appened the signature to the document and return it. Currently, it supports the following sign algorithm:
+`signDocument` takes a wrapped document, as well as a public/private key pair or an [Ethers.js Signer](https://docs.ethers.io/v5/api/signer/). The method will sign the merkle root from the wrapped document, append the signature to the document and return it. Currently, it supports the following sign algorithm:
 
 - `Secp256k1VerificationKey2018`
 


### PR DESCRIPTION
* Removed incorrect example on v3 usage (issue #222 )
* Correct usage now in Additional Information
* fix some typos and grammar
* Mention that docs can also be signed instead of storing the hash on-chain ("did-signed")