### PR TITLE
fix: utils

### DIFF
--- a/src/shared/utils/__tests__/utils.test.ts
+++ b/src/shared/utils/__tests__/utils.test.ts
@@ -10,6 +10,7 @@ import v2WrappedVerifiableDocument from "../../../../test/fixtures/v2/not-obfusc
 import v3WrappedVerifiableDocument from "../../../../test/fixtures/v3/not-obfuscated-wrapped.json";
 import v2WrappedDidDocument from "../../../../test/fixtures/v2/did-wrapped.json";
 import v3WrappedDidDocument from "../../../../test/fixtures/v3/did-wrapped.json";
+import v2WrappedDidDocumentOscpResponder from "../../../../test/fixtures/v2/did-signed-ocsp-responder.json";
 import v2WrappedTransferableDocument from "../../../../test/fixtures/v2/wrapped-transferable-document.json";
 import v3WrappedTransferableDocument from "../../../../test/fixtures/v3/wrapped-transferable-document.json";
 import v2VerifiableDocumentForm from "../../../../test/fixtures/v2/verifiable-document-form.json";
@@ -312,6 +313,11 @@ describe("Util Functions", () => {
     it("should return true for a revokable V2 verifiable document with document store", () => {
       expect(utils.isDocumentRevokable(v2WrappedVerifiableDocument)).toStrictEqual(true);
     });
+
+    it("should return true for a revokable V2 did verifiable document with oscp responder", () => {
+      expect(utils.isDocumentRevokable(v2WrappedDidDocumentOscpResponder)).toStrictEqual(true);
+    });
+
     it("should return true for a revokable v3 verifiable document", () => {
       expect(utils.isDocumentRevokable(v3WrappedVerifiableDocument)).toStrictEqual(true);
     });

--- a/test/fixtures/v2/did-signed-ocsp-responder.json
+++ b/test/fixtures/v2/did-signed-ocsp-responder.json
@@ -1,0 +1,43 @@
+{
+  "version": "https://schema.openattestation.com/2.0/schema.json",
+  "data": {
+    "recipient": {
+      "name": "4832d0e2-3789-48e2-b4a8-851894151049:string:John Doe"
+    },
+    "$template": {
+      "name": "67b15c79-78d0-4c79-a9cc-7506e302c7e6:string:main",
+      "type": "7ca5b55c-db1c-484d-b004-f0b36c1444f3:string:EMBEDDED_RENDERER",
+      "url": "2ef7bef4-fc09-4b3a-9ec7-40eea960f0cf:string:https://tutorial-renderer.openattestation.com"
+    },
+    "issuers": [
+      {
+        "id": "92995b17-deb4-4b33-bef6-81610264eb52:string:did:ethr:0x1245e5B64D785b25057f7438F715f4aA5D965733",
+        "name": "570c0fea-37a0-4cc2-b895-705b61e0b1fd:string:Demo Issuer",
+        "revocation": {
+          "type": "aa617a82-ad07-49ce-8248-a57407182def:string:OCSP_RESPONDER",
+          "location": "42508d06-8e5b-44b5-b8f1-f3130aea3f3d:string:https://tradetrust-functions.netlify.app/.netlify/functions/ocsp-responder"
+        },
+        "identityProof": {
+          "type": "67bc586d-a98d-41d5-abd0-9a66bafa0d3e:string:DNS-DID",
+          "location": "816b64fb-4ae0-425c-bb76-d78c4f235678:string:demo-tradetrust.openattestation.com",
+          "key": "d1bb7293-8be0-4502-9aab-636cd135eb1b:string:did:ethr:0x1245e5B64D785b25057f7438F715f4aA5D965733#controller"
+        }
+      }
+    ]
+  },
+  "signature": {
+    "type": "SHA3MerkleProof",
+    "targetHash": "fdf21f11a131867c06a2c4291f1581d8a2c8ff08dec160e7989981bae0e7e5fb",
+    "proof": [],
+    "merkleRoot": "fdf21f11a131867c06a2c4291f1581d8a2c8ff08dec160e7989981bae0e7e5fb"
+  },
+  "proof": [
+    {
+      "type": "OpenAttestationSignature2018",
+      "created": "2022-10-26T06:23:20.841Z",
+      "proofPurpose": "assertionMethod",
+      "verificationMethod": "did:ethr:0x1245e5B64D785b25057f7438F715f4aA5D965733#controller",
+      "signature": "0x049928f8295da01503a3190a5c648f237ca3e3c20c15c8eb1fe12dbf5d966fe51ed541f09d0d5641fef4f3c3ae0b8279ce37919fe2d39030d1b0056f5778df5d1c"
+    }
+  ]
+}

--- a/test/fixtures/v2/did-signed-ocsp-responder.json
+++ b/test/fixtures/v2/did-signed-ocsp-responder.json
@@ -2,42 +2,33 @@
   "version": "https://schema.openattestation.com/2.0/schema.json",
   "data": {
     "recipient": {
-      "name": "4832d0e2-3789-48e2-b4a8-851894151049:string:John Doe"
+      "name": "18134e8a-9e44-4269-b02b-53b0d82897d6:string:John Doe"
     },
     "$template": {
-      "name": "67b15c79-78d0-4c79-a9cc-7506e302c7e6:string:main",
-      "type": "7ca5b55c-db1c-484d-b004-f0b36c1444f3:string:EMBEDDED_RENDERER",
-      "url": "2ef7bef4-fc09-4b3a-9ec7-40eea960f0cf:string:https://tutorial-renderer.openattestation.com"
+      "name": "835c455c-c862-404f-9dff-e45f0e84b4c6:string:main",
+      "type": "9a60d273-f6c6-48a3-83ab-a88feecb9ab1:string:EMBEDDED_RENDERER",
+      "url": "4898fb9d-f1ee-4897-8d8f-c31cde38f597:string:https://tutorial-renderer.openattestation.com"
     },
     "issuers": [
       {
-        "id": "92995b17-deb4-4b33-bef6-81610264eb52:string:did:ethr:0x1245e5B64D785b25057f7438F715f4aA5D965733",
-        "name": "570c0fea-37a0-4cc2-b895-705b61e0b1fd:string:Demo Issuer",
+        "id": "610773d0-840e-46bd-8b47-8e8cf2b9012f:string:did:ethr:0x1245e5B64D785b25057f7438F715f4aA5D965733",
+        "name": "62fe5e04-2eed-4481-8a27-13622efe1abd:string:Demo Issuer",
         "revocation": {
-          "type": "aa617a82-ad07-49ce-8248-a57407182def:string:OCSP_RESPONDER",
-          "location": "42508d06-8e5b-44b5-b8f1-f3130aea3f3d:string:https://tradetrust-functions.netlify.app/.netlify/functions/ocsp-responder"
+          "type": "afd351c5-bf83-4956-a3a8-faa89354718c:string:OCSP_RESPONDER",
+          "location": "c578a822-03ab-4a79-b10a-a37fd7b0d9d7:string:https://api.example.com/ocsp-responder"
         },
         "identityProof": {
-          "type": "67bc586d-a98d-41d5-abd0-9a66bafa0d3e:string:DNS-DID",
-          "location": "816b64fb-4ae0-425c-bb76-d78c4f235678:string:demo-tradetrust.openattestation.com",
-          "key": "d1bb7293-8be0-4502-9aab-636cd135eb1b:string:did:ethr:0x1245e5B64D785b25057f7438F715f4aA5D965733#controller"
+          "type": "26a7fea3-46ef-4613-a61f-914a0f06312d:string:DNS-DID",
+          "location": "15f58a9b-04ba-49f2-925d-f5b065f5f847:string:demo-tradetrust.openattestation.com",
+          "key": "720aa75e-720d-4f12-a6e9-6bee1f758f1a:string:did:ethr:0x1245e5B64D785b25057f7438F715f4aA5D965733#controller"
         }
       }
     ]
   },
   "signature": {
     "type": "SHA3MerkleProof",
-    "targetHash": "fdf21f11a131867c06a2c4291f1581d8a2c8ff08dec160e7989981bae0e7e5fb",
+    "targetHash": "c1c9dcdcf4d1027449f7db66e25cf12f3f83c8a89582a3c09bbc701491989ed8",
     "proof": [],
-    "merkleRoot": "fdf21f11a131867c06a2c4291f1581d8a2c8ff08dec160e7989981bae0e7e5fb"
-  },
-  "proof": [
-    {
-      "type": "OpenAttestationSignature2018",
-      "created": "2022-10-26T06:23:20.841Z",
-      "proofPurpose": "assertionMethod",
-      "verificationMethod": "did:ethr:0x1245e5B64D785b25057f7438F715f4aA5D965733#controller",
-      "signature": "0x049928f8295da01503a3190a5c648f237ca3e3c20c15c8eb1fe12dbf5d966fe51ed541f09d0d5641fef4f3c3ae0b8279ce37919fe2d39030d1b0056f5778df5d1c"
-    }
-  ]
+    "merkleRoot": "c1c9dcdcf4d1027449f7db66e25cf12f3f83c8a89582a3c09bbc701491989ed8"
+  }
 }


### PR DESCRIPTION
- add check for revocation type `OCSP_RESPONDER` to `isDocumentRevokable` utils.
- v3 [no support](https://github.com/Open-Attestation/oa-verify/blob/master/src/verifiers/documentStatus/didSigned/didSignedDocumentStatus.ts#L266) of `OCSP_RESPONDER` yet, so we omit.