### PR TITLE
chore: remove required fields

### DIFF
--- a/src/4.0/schema/schema.json
+++ b/src/4.0/schema/schema.json
@@ -133,7 +133,7 @@
           "description": "URL of a decentralised renderer to render this document"
         }
       },
-      "required": ["renderMethodType", "name", "url"]
+      "required": ["name"]
     },
     "credentialSubject": {
       "type": "object",


### PR DESCRIPTION
Remove some required fields from `renderMethod` in order to support SVG rendering