### PR TITLE
chore: sign document should be clear on what errors it could throw, export of v4 verify shd be more explicit

### DIFF
--- a/src/4.0/__tests__/sign.test.ts
+++ b/src/4.0/__tests__/sign.test.ts
@@ -88,8 +88,8 @@ describe("V4 sign", () => {
         }
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
-      "Document has not been properly wrapped: 
-       {
+      "Document has not been properly wrapped:
+      {
         "_errors": [],
         "proof": {
           "_errors": [],

--- a/src/4.0/exports/verify.ts
+++ b/src/4.0/exports/verify.ts
@@ -1,1 +1,1 @@
-export { verify } from "../verify";
+export { verify as verifySignature } from "../verify";


### PR DESCRIPTION
# Why
its possible for signing to throw errors when network is down, signer or keys are misconfigured

# What
1. Added a new `CouldNotSignDocumentError` and exported it
2. `verify` is now exported as `verifySignature`