### PR TITLE
fix: clean up hashing utils from utils and fix broken references

### DIFF
--- a/src/shared/utils/__tests__/utils.test.ts
+++ b/src/shared/utils/__tests__/utils.test.ts
@@ -1,4 +1,5 @@
 import * as utils from "../utils";
+import * as hashingUtils from "../hashing";
 import { wrapDocument } from "../../..";
 import { OpenAttestationDocument, WrappedDocument } from "../../../shared/@types/document";
 import * as v2 from "../../../__generated__/schema.2.0";
@@ -16,7 +17,7 @@ import v3WrappedTransferableDocument from "../../../../test/fixtures/v3/wrapped-
 describe("Util Functions", () => {
   describe("hashArray", () => {
     test("should work", () => {
-      const res = utils.hashArray(["a", "b", "1", 5]);
+      const res = hashingUtils.hashArray(["a", "b", "1", 5]);
 
       const expectedHashResults = [
         "660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc",
@@ -31,7 +32,7 @@ describe("Util Functions", () => {
 
   describe("bufSortJoin", () => {
     test("should work", () => {
-      const res = utils.bufSortJoin(Buffer.from("c"), Buffer.from("b"), Buffer.from("a"));
+      const res = hashingUtils.bufSortJoin(Buffer.from("c"), Buffer.from("b"), Buffer.from("a"));
       const expectedResults = "616263";
       expect(res.toString("hex")).toEqual(expectedResults);
     });
@@ -39,35 +40,35 @@ describe("Util Functions", () => {
 
   describe("hashToBuffer", () => {
     test("should work", () => {
-      expect(utils.hashToBuffer("foo")).toEqual(Buffer.from("foo", "hex"));
+      expect(hashingUtils.hashToBuffer("foo")).toEqual(Buffer.from("foo", "hex"));
     });
 
     test("should do nothing if the input is a hash", () => {
       const originalBuffer = Buffer.from("foo", "utf8");
-      expect(utils.hashToBuffer(originalBuffer)).toEqual(originalBuffer);
+      expect(hashingUtils.hashToBuffer(originalBuffer)).toEqual(originalBuffer);
     });
   });
 
   describe("toBuffer", () => {
     test("should work", () => {
-      expect(utils.toBuffer("foo").toString("hex")).toEqual(
+      expect(hashingUtils.toBuffer("foo").toString("hex")).toEqual(
         "837fb5aa99ab7d0392fa43e61f529f072a693fd38032cd4a039793a9f9b4ea42"
       );
     });
 
     test("should do nothing if the input is a hash", () => {
-      const originalBuffer = utils.toBuffer("foo");
-      expect(utils.toBuffer(originalBuffer)).toEqual(originalBuffer);
+      const originalBuffer = hashingUtils.toBuffer("foo");
+      expect(hashingUtils.toBuffer(originalBuffer)).toEqual(originalBuffer);
     });
   });
 
   describe("combineHashBuffers", () => {
     test("should combine two hashes (in buffer format) and return result as a string", () => {
       expect(
-        utils
+        hashingUtils
           .combineHashBuffers(
-            utils.hashToBuffer("660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc"),
-            utils.hashToBuffer("9261495095bfbb82deedb97b2be90d0f4c0d9a03fdd90a9da62c1bbcc45d7eb2")
+            hashingUtils.hashToBuffer("660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc"),
+            hashingUtils.hashToBuffer("9261495095bfbb82deedb97b2be90d0f4c0d9a03fdd90a9da62c1bbcc45d7eb2")
           )
           .toString("hex")
       ).toBe("6a4fe9cb57c9f79964c0408f25d70a73b3448bc6e975d0a905f0f8694764954b");
@@ -75,15 +76,17 @@ describe("Util Functions", () => {
 
     test("should return original hash if only one is given", () => {
       expect(
-        utils
-          .combineHashBuffers(utils.hashToBuffer("660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc"))
+        hashingUtils
+          .combineHashBuffers(
+            hashingUtils.hashToBuffer("660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc")
+          )
           .toString("hex")
       ).toBe("660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc");
       expect(
-        utils
+        hashingUtils
           .combineHashBuffers(
             undefined,
-            utils.hashToBuffer("660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc")
+            hashingUtils.hashToBuffer("660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc")
           )
           .toString("hex")
       ).toBe("660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc");
@@ -93,7 +96,7 @@ describe("Util Functions", () => {
   describe("combineHashString", () => {
     test("should combine two hashes (in string format) and return result as a string", () => {
       expect(
-        utils.combineHashString(
+        hashingUtils.combineHashString(
           "660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc",
           "9261495095bfbb82deedb97b2be90d0f4c0d9a03fdd90a9da62c1bbcc45d7eb2"
         )
@@ -101,11 +104,11 @@ describe("Util Functions", () => {
     });
 
     test("should return original hash if only one is given", () => {
-      expect(utils.combineHashString("660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc")).toBe(
+      expect(hashingUtils.combineHashString("660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc")).toBe(
         "660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc"
       );
       expect(
-        utils.combineHashString(undefined, "660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc")
+        hashingUtils.combineHashString(undefined, "660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc")
       ).toBe("660c9a8d0051d07b1abd38e8a6f68076d98fdf948abd2a13e2870fe08a1343cc");
     });
   });

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./utils";
 export * from "./guard";
 export * from "./diagnose";
 export * from "../../2.0/utils";
+export * from "./hashing";

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -1,5 +1,4 @@
 import { ErrorObject } from "ajv";
-import { keccak256 } from "js-sha3";
 
 import * as v2 from "../../__generated__/schema.2.0";
 import { getData } from "../../2.0/utils";
@@ -23,62 +22,6 @@ import {
   isWrappedV4Document,
 } from "./guard";
 import { Version } from "./diagnose";
-
-export type Hash = string | Buffer;
-
-/**
- * Sorts the given Buffers lexicographically and then concatenates them to form one continuous Buffer
- */
-export function bufSortJoin(...args: Buffer[]): Buffer {
-  return Buffer.concat([...args].sort(Buffer.compare));
-}
-
-// If hash is not a buffer, convert it to buffer (without hashing it)
-export function hashToBuffer(hash: Hash): Buffer {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore https://github.com/Microsoft/TypeScript/issues/23155
-  return Buffer.isBuffer(hash) && hash.length === 32 ? hash : Buffer.from(hash, "hex");
-}
-
-// If element is not a buffer, stringify it and then hash it to be a buffer
-export function toBuffer(element: any): Buffer {
-  return Buffer.isBuffer(element) && element.length === 32 ? element : hashToBuffer(keccak256(JSON.stringify(element)));
-}
-/**
- * Turns array of data into sorted array of hashes
- */
-export function hashArray(arr: any[]) {
-  return arr.map((i) => toBuffer(i)).sort(Buffer.compare);
-}
-
-/**
- * Returns the keccak hash of two buffers after concatenating them and sorting them
- * If either hash is not given, the input is returned
- */
-export function combineHashBuffers(first?: Buffer, second?: Buffer): Buffer {
-  if (!second) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return first!; // it should always be valued if second is not
-  }
-  if (!first) {
-    return second;
-  }
-  return hashToBuffer(keccak256(bufSortJoin(first, second)));
-}
-
-/**
- * Returns the keccak hash of two string after concatenating them and sorting them
- * If either hash is not given, the input is returned
- * @param first A string to be hashed (without 0x)
- * @param second A string to be hashed (without 0x)
- * @returns Resulting string after the hash is combined (without 0x)
- */
-export function combineHashString(first?: string, second?: string): string {
-  return first && second
-    ? combineHashBuffers(hashToBuffer(first), hashToBuffer(second)).toString("hex")
-    : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      (first || second)!; // this should always return a value right ? :)
-}
 
 export function getIssuerAddress(document: any): any {
   if (isWrappedV2Document(document)) {


### PR DESCRIPTION
## Why
Hashing utils were being mixed with stuff from other versions, using these utils were forcing v4 specific users to import other things that are not needed

## What
An earlier pr created a dedicated hashing module already.

1. Clean up hashing utils from `utils.ts`
2. Export from `hashing.ts` instead to preserve the utils interface
3. Fix broken references