### PR TITLE
fix: bump target platform, and remove baseUrl as it is not supported

### DIFF
--- a/src/shared/@types/document.ts
+++ b/src/shared/@types/document.ts
@@ -11,7 +11,7 @@ import {
 } from "../../3.0/types";
 import { Literal, Static, String } from "runtypes";
 import { ethers } from "ethers";
-import { V4Document, V4SignedWrappedDocument, V4WrappedDocument } from "src/4.0/types";
+import { V4Document, V4SignedWrappedDocument, V4WrappedDocument } from "../../4.0/types";
 
 export type OpenAttestationDocument = OpenAttestationDocumentV2 | OpenAttestationDocumentV3 | V4Document;
 export type WrappedDocument<T extends OpenAttestationDocument> = T extends OpenAttestationDocumentV2

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,17 +3,26 @@
     "files": true
   },
   "compilerOptions": {
-    "lib": ["es2019"],
-    "target": "es5",
-    "module": "commonjs",
-    "moduleResolution": "node",
     "strict": true,
-    "baseUrl": ".",
+    // affects emission
+    "module": "commonjs",
+
+    "moduleResolution": "node",
+    // affects emission
+    // 98% browser support (https://caniuse.com/?search=es6)
+    // Node >12 already supports ES2019 (https://node.green/#ES2019)
+    "target": "ES6",
+
+    // 96% browser support (https://caniuse.com/array-flat)
+    "lib": ["ES2019.Array"],
     "typeRoots": ["./src/@types", "./node_modules/@types"],
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    // affects emission
     "esModuleInterop": true,
-    "allowJs": true
+    
+    "allowJs": true,
+    "outDir": "./dist"
   },
   "include": ["./src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,13 +6,11 @@
     "strict": true,
     // affects emission
     "module": "commonjs",
-
     "moduleResolution": "node",
     // affects emission
     // 98% browser support (https://caniuse.com/?search=es6)
     // Node >12 already supports ES2019 (https://node.green/#ES2019)
     "target": "ES6",
-
     // 96% browser support (https://caniuse.com/array-flat)
     "lib": ["ES2019.Array"],
     "typeRoots": ["./src/@types", "./node_modules/@types"],
@@ -20,7 +18,6 @@
     "resolveJsonModule": true,
     // affects emission
     "esModuleInterop": true,
-    
     "allowJs": true,
     "outDir": "./dist"
   },


### PR DESCRIPTION
## why
1. es6 is already widely adopted by modern browsers 98% and node v12 and above
2. narrow es2019 to es2019's array method as not all of es2019 is available in modern browsers
3. `baseUrl` is misleading, cos root imports will not work unless there is post processing from something like a bundler
