### PR TITLE
fix: polyfill buffer, shim randombytes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@govtechsg/jsonld": "^0.1.0",
+        "buffer": "^6.0.3",
         "cross-fetch": "^3.1.5",
         "debug": "^4.3.2",
         "ethers": "^5.7.2",
@@ -19,6 +20,7 @@
         "js-sha3": "^0.8.0",
         "jsonld": "^8.3.2",
         "lodash": "^4.17.21",
+        "randombytes": "^2.1.0",
         "runtypes": "^6.3.2",
         "uuid": "^8.3.2",
         "validator": "^13.7.0",
@@ -35,6 +37,7 @@
         "@types/jsonld": "^1.5.13",
         "@types/lodash": "^4.14.171",
         "@types/qrcode": "^1.4.1",
+        "@types/randombytes": "^2.0.3",
         "@types/uuid": "^8.3.1",
         "@types/validator": "^13.6.3",
         "@typescript-eslint/eslint-plugin": "^6.9.0",
@@ -3764,6 +3767,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/randombytes": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/randombytes/-/randombytes-2.0.3.tgz",
+      "integrity": "sha512-+NRgihTfuURllWCiIAhm1wsJqzsocnqXM77V/CalsdJIYSRGEHMnritxh+6EsBklshC+clo1KgnN14qgSGeQdw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
@@ -4863,7 +4875,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4899,6 +4910,30 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bn.js": {
@@ -5060,10 +5095,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -5080,7 +5114,7 @@
       ],
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-equal": {
@@ -8522,7 +8556,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15309,6 +15342,14 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -15807,7 +15848,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/jsonld": "^1.5.13",
     "@types/lodash": "^4.14.171",
     "@types/qrcode": "^1.4.1",
+    "@types/randombytes": "^2.0.3",
     "@types/uuid": "^8.3.1",
     "@types/validator": "^13.6.3",
     "@typescript-eslint/eslint-plugin": "^6.9.0",
@@ -99,6 +100,7 @@
   },
   "dependencies": {
     "@govtechsg/jsonld": "^0.1.0",
+    "buffer": "^6.0.3",
     "cross-fetch": "^3.1.5",
     "debug": "^4.3.2",
     "ethers": "^5.7.2",
@@ -107,6 +109,7 @@
     "js-sha3": "^0.8.0",
     "jsonld": "^8.3.2",
     "lodash": "^4.17.21",
+    "randombytes": "^2.1.0",
     "runtypes": "^6.3.2",
     "uuid": "^8.3.2",
     "validator": "^13.7.0",

--- a/src/2.0/wrap.ts
+++ b/src/2.0/wrap.ts
@@ -59,7 +59,7 @@ export const wrapDocuments = <T extends OpenAttestationDocument = OpenAttestatio
   return documents.map((document) => {
     const merkleProof = merkleTree
       .getProof(hashToBuffer(document.signature.targetHash))
-      .map((buffer: Buffer) => buffer.toString("hex"));
+      .map((buffer) => buffer.toString("hex"));
     return {
       ...document,
       signature: {

--- a/src/3.0/salt.ts
+++ b/src/3.0/salt.ts
@@ -1,5 +1,5 @@
 import { Salt } from "./types";
-import { randomBytes } from "crypto";
+import randomBytes from "randombytes";
 import { Base64 } from "js-base64";
 import { traverseAndFlatten } from "./traverseAndFlatten";
 

--- a/src/3.0/wrap.ts
+++ b/src/3.0/wrap.ts
@@ -43,7 +43,7 @@ export const wrapDocument = async <T extends OpenAttestationDocument>(
 
   const merkleTree = new MerkleTree(batchBuffers);
   const merkleRoot = merkleTree.getRoot().toString("hex");
-  const merkleProof = merkleTree.getProof(hashToBuffer(digest)).map((buffer: Buffer) => buffer.toString("hex"));
+  const merkleProof = merkleTree.getProof(hashToBuffer(digest)).map((buffer) => buffer.toString("hex"));
 
   const verifiableCredential: WrappedDocument<T> = {
     ...document,
@@ -83,7 +83,7 @@ export const wrapDocuments = async <T extends OpenAttestationDocument>(
   // for each document, update the merkle root and add the proofs needed
   return verifiableCredentials.map((verifiableCredential) => {
     const digest = verifiableCredential.proof.targetHash;
-    const merkleProof = merkleTree.getProof(hashToBuffer(digest)).map((buffer: Buffer) => buffer.toString("hex"));
+    const merkleProof = merkleTree.getProof(hashToBuffer(digest)).map((buffer) => buffer.toString("hex"));
 
     return {
       ...verifiableCredential,

--- a/src/4.0/salt.ts
+++ b/src/4.0/salt.ts
@@ -1,7 +1,7 @@
 import { Salt } from "./types";
-import { randomBytes } from "crypto";
 import { Base64 } from "js-base64";
 import { traverseAndFlatten } from "./traverseAndFlatten";
+import randomBytes from "randombytes";
 
 const ENTROPY_IN_BYTES = 32;
 

--- a/src/4.0/wrap.ts
+++ b/src/4.0/wrap.ts
@@ -74,7 +74,7 @@ export const wrapDocument = async <T extends V4Document>(
 
   const merkleTree = new MerkleTree(batchBuffers);
   const merkleRoot = merkleTree.getRoot().toString("hex");
-  const merkleProof = merkleTree.getProof(hashToBuffer(digest)).map((buffer: Buffer) => buffer.toString("hex"));
+  const merkleProof = merkleTree.getProof(hashToBuffer(digest)).map((buffer) => buffer.toString("hex"));
   const verifiableCredential: V4WrappedDocument = {
     ...documentReadyForWrapping,
     proof: {
@@ -109,7 +109,7 @@ export const wrapDocuments = async <T extends V4Document>(
   // for each document, update the merkle root and add the proofs needed
   return verifiableCredentials.map((verifiableCredential) => {
     const digest = verifiableCredential.proof.targetHash;
-    const merkleProof = merkleTree.getProof(hashToBuffer(digest)).map((buffer: Buffer) => buffer.toString("hex"));
+    const merkleProof = merkleTree.getProof(hashToBuffer(digest)).map((buffer) => buffer.toString("hex"));
 
     return {
       ...verifiableCredential,

--- a/src/shared/merkle/merkle.ts
+++ b/src/shared/merkle/merkle.ts
@@ -1,4 +1,5 @@
 import { Hash, hashArray, toBuffer, hashToBuffer, combineHashBuffers } from "../utils/hashing";
+import { Buffer } from "buffer/";
 
 function getNextLayer(elements: Buffer[]) {
   return elements.reduce((layer: Buffer[], element, index, arr) => {

--- a/src/shared/utils/__tests__/utils.test.ts
+++ b/src/shared/utils/__tests__/utils.test.ts
@@ -13,6 +13,7 @@ import v3WrappedDidDocument from "../../../../test/fixtures/v3/did-wrapped.json"
 import v2WrappedDidDocumentOscpResponder from "../../../../test/fixtures/v2/did-signed-ocsp-responder.json";
 import v2WrappedTransferableDocument from "../../../../test/fixtures/v2/wrapped-transferable-document.json";
 import v3WrappedTransferableDocument from "../../../../test/fixtures/v3/wrapped-transferable-document.json";
+import { Buffer } from "buffer/";
 
 describe("Util Functions", () => {
   describe("hashArray", () => {

--- a/src/shared/utils/hashing.ts
+++ b/src/shared/utils/hashing.ts
@@ -1,5 +1,5 @@
 import { keccak256 } from "js-sha3";
-import { Buffer } from "buffer/index";
+import { Buffer } from "buffer/";
 
 export type Hash = string | Buffer;
 /**

--- a/src/shared/utils/hashing.ts
+++ b/src/shared/utils/hashing.ts
@@ -1,4 +1,5 @@
 import { keccak256 } from "js-sha3";
+import { Buffer } from "buffer/index";
 
 export type Hash = string | Buffer;
 /**


### PR DESCRIPTION
## What
1. remove direct use of crypto and instead use https://www.npmjs.com/package/randombytes, which uses native crypto methods based on environment
2. use https://www.npmjs.com/package/buffer instead of relying on buffer from node env

## Tested
1. CRA - works out of the box
2. React vite needs 
```
// vite.config.ts
export default defineConfig({
  plugins: [react()],
  define: {
    // By default, Vite doesn't include shims for NodeJS/
    // necessary for segment analytics lib to work
    global: 'globalThis'
  },  
})
```
3. next server side - out of the box
4. next client side - have to install `undici`