### PR TITLE
fix: rendering methods

### DIFF
--- a/src/4.0/__tests__/documentBuilder.test.ts
+++ b/src/4.0/__tests__/documentBuilder.test.ts
@@ -252,6 +252,64 @@ describe(`DocumentBuilder`, () => {
     expect(signed).not.toHaveProperty("anotherProperty");
   });
 
+  test("given svg rendering method, should be added into the document", async () => {
+    const signed = await new DocumentBuilder({
+      content: { name: "John Doe" },
+      name: "Diploma",
+      attachments: [
+        {
+          data: "data",
+          fileName: "file",
+          mimeType: "application/pdf",
+        },
+      ],
+    })
+      .svgRenderer({
+        type: "EMBEDDED",
+        svgTemplate: "<svg>{{ name }}</svg>",
+      })
+      .noRevocation()
+      .dnsTxtIssuance({
+        identityProofDomain: "example.com",
+        issuerId: "did:example:123",
+        issuerName: "Example University",
+      })
+      .wrapAndSign({ signer: SAMPLE_SIGNING_KEYS });
+
+    expect(signed.renderMethod).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "<svg>{{ name }}</svg>",
+          "type": "SvgRenderingTemplate2023",
+        },
+      ]
+    `);
+  });
+
+  test("given no rendering method, should reflect in the output document", async () => {
+    const signed = await new DocumentBuilder({
+      content: { name: "John Doe" },
+      name: "Diploma",
+      attachments: [
+        {
+          data: "data",
+          fileName: "file",
+          mimeType: "application/pdf",
+        },
+      ],
+    })
+      .noRenderer()
+      .noRevocation()
+      .dnsTxtIssuance({
+        identityProofDomain: "example.com",
+        issuerId: "did:example:123",
+        issuerName: "Example University",
+      })
+      .wrapAndSign({ signer: SAMPLE_SIGNING_KEYS });
+
+    expect(signed.renderMethod).toMatchInlineSnapshot(`undefined`);
+  });
+
   test("given attachment is added, should be added into the document", async () => {
     const signed = await new DocumentBuilder({
       content: { name: "John Doe" },

--- a/src/4.0/__tests__/documentBuilder.test.ts
+++ b/src/4.0/__tests__/documentBuilder.test.ts
@@ -5,7 +5,7 @@ import { SAMPLE_SIGNING_KEYS } from "../fixtures";
 
 describe(`DocumentBuilder`, () => {
   describe("given a single document", () => {
-    const document = new DocumentBuilder({ content: { name: "John Doe" }, name: "Diploma" })
+    const document = new DocumentBuilder({ credentialSubject: { name: "John Doe" }, name: "Diploma" })
       .embeddedRenderer({
         rendererUrl: "https://example.com",
         templateName: "example",
@@ -96,8 +96,8 @@ describe(`DocumentBuilder`, () => {
 
   describe("given a multiple documents", () => {
     const document = new DocumentBuilder([
-      { content: { name: "John Doe" }, name: "Diploma" },
-      { content: { name: "Jane Foster" }, name: "Degree" },
+      { credentialSubject: { name: "John Doe" }, name: "Diploma" },
+      { credentialSubject: { name: "Jane Foster" }, name: "Degree" },
     ])
       .embeddedRenderer({
         rendererUrl: "https://example.com",
@@ -233,7 +233,7 @@ describe(`DocumentBuilder`, () => {
 
   test("given additional properties in constructor payload, should not be added into the document", async () => {
     const signed = await new DocumentBuilder({
-      content: { name: "John Doe" },
+      credentialSubject: { name: "John Doe" },
       name: "Diploma",
       anotherProperty: "value",
     })
@@ -254,7 +254,7 @@ describe(`DocumentBuilder`, () => {
 
   test("given svg rendering method, should be added into the document", async () => {
     const signed = await new DocumentBuilder({
-      content: { name: "John Doe" },
+      credentialSubject: { name: "John Doe" },
       name: "Diploma",
       attachments: [
         {
@@ -288,7 +288,7 @@ describe(`DocumentBuilder`, () => {
 
   test("given no rendering method, should reflect in the output document", async () => {
     const signed = await new DocumentBuilder({
-      content: { name: "John Doe" },
+      credentialSubject: { name: "John Doe" },
       name: "Diploma",
       attachments: [
         {
@@ -312,7 +312,7 @@ describe(`DocumentBuilder`, () => {
 
   test("given attachment is added, should be added into the document", async () => {
     const signed = await new DocumentBuilder({
-      content: { name: "John Doe" },
+      credentialSubject: { name: "John Doe" },
       name: "Diploma",
       attachments: [
         {
@@ -347,7 +347,7 @@ describe(`DocumentBuilder`, () => {
 
   test("given revocation store revocation is added, should be added into credential status of the document", async () => {
     const signed = await new DocumentBuilder({
-      content: { name: "John Doe" },
+      credentialSubject: { name: "John Doe" },
       name: "Diploma",
       attachments: [
         {
@@ -381,7 +381,7 @@ describe(`DocumentBuilder`, () => {
 
   test("given wrap only is called, should be able to sign the wrapped document with the standalone sign fn", async () => {
     const wrapped = await new DocumentBuilder({
-      content: { name: "John Doe" },
+      credentialSubject: { name: "John Doe" },
       name: "Diploma",
     })
       .embeddedRenderer({
@@ -404,7 +404,7 @@ describe(`DocumentBuilder`, () => {
 
   test("given re-setting of values, should throw", async () => {
     const builder = await new DocumentBuilder({
-      content: { name: "John Doe" },
+      credentialSubject: { name: "John Doe" },
       name: "Diploma",
     });
 
@@ -446,7 +446,7 @@ describe(`DocumentBuilder`, () => {
       expect(() => {
         try {
           new DocumentBuilder({
-            content: { name: "John Doe" },
+            credentialSubject: { name: "John Doe" },
             name: "Diploma",
             attachments: [
               {
@@ -465,7 +465,7 @@ describe(`DocumentBuilder`, () => {
 
     test("given an invalid identity identifier, should throw", () => {
       const builder = new DocumentBuilder({
-        content: { name: "John Doe" },
+        credentialSubject: { name: "John Doe" },
         name: "Diploma",
       })
         .embeddedRenderer({
@@ -501,7 +501,7 @@ describe(`DocumentBuilder`, () => {
 
     test("given an invalid ethereum address for revocation store, should throw", () => {
       const builder = new DocumentBuilder({
-        content: { name: "John Doe" },
+        credentialSubject: { name: "John Doe" },
         name: "Diploma",
       }).embeddedRenderer({
         rendererUrl: "https://example.com",

--- a/src/4.0/documentBuilder.ts
+++ b/src/4.0/documentBuilder.ts
@@ -130,7 +130,7 @@ export class DocumentBuilder<Props extends DocumentProps | DocumentProps[]> {
             issuer,
             name,
             credentialSubject: content,
-            renderMethod,
+            ...(renderMethod && { renderMethod }),
             ...(attachments && { attachments }),
             ...(credentialStatus && { credentialStatus }),
           } satisfies V4Document)

--- a/src/4.0/documentBuilder.ts
+++ b/src/4.0/documentBuilder.ts
@@ -307,7 +307,13 @@ export class DocumentBuilder<Props extends DocumentProps | DocumentProps[]> {
     return this.REVOCATION_METHODS;
   };
 
-  /** Render via an SVG template, embedded or remote */
+  /**
+   * Render via an SVG handlebar template, embedded or remote
+   * the root object of the handlebar template should be the content of the document
+   * that is the "credentialSubject" of the final OpenAttestation document
+   * for example, if the content of the document is { name: "John Doe" }
+   * the handlebar template should refer to the name as {{name}}
+   */
   public svgRenderer = (
     props:
       | {


### PR DESCRIPTION
## What
1. add an option to not have any rendering method
2. an important svg rendering property were missing, added `digestMultibase`
3. discriminated types for svg, so that with a embedded svg digest is never needed, where remote, user has option to add digest multibase
4. add test