### PR TITLE
fix: generate fixtures only on change

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,5 @@
 {
     "src/4.0/types.ts": ["npm run generate-v4-json-schemas", "git add src/4.0/jsonSchemas/__generated__"],
+    "src/4.0/fixtures.ts": ["npm run generate-v4-fixtures", "git add test/fixtures/v4/__generated__"],
     "*.{js,ts}": "eslint --fix"
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "generate-v4-fixtures": "npx ts-node scripts/generateV4JsonFixtures.ts",
     "generate-v4-json-schemas": "npx ts-node scripts/generateV4JsonSchemas.ts",
     "publish:schema": "./scripts/publishSchema.sh",
-    "postinstall": "node scripts/postInstall; npm run generate-v4-fixtures",
+    "postinstall": "node scripts/postInstall;",
     "prebuild": "node scripts/preBuild",
     "prepare": "husky install"
   },


### PR DESCRIPTION
## why
1. not needed to run on each install\
2. scripts break when ran in project that is not of the expected module type

## what
to run script on precommit hook when fixtures.ts changes