### PR TITLE
fix: obfuscation return type should still have a compliant attachment…

### DIFF
--- a/src/4.0/obfuscate.ts
+++ b/src/4.0/obfuscate.ts
@@ -68,7 +68,12 @@ const obfuscate = (_data: V4WrappedDocument, fields: string[] | string) => {
 
 export type ObfuscateVerifiableCredentialResult<T extends V4WrappedDocument> = Override<
   T,
-  { credentialSubject: PartialDeep<T["credentialSubject"]> }
+  {
+    credentialSubject: Override<
+      PartialDeep<T["credentialSubject"]>,
+      { attachments?: V4WrappedDocument["credentialSubject"]["attachments"] }
+    >;
+  }
 >;
 export const obfuscateVerifiableCredential = <T extends V4WrappedDocument | V4SignedWrappedDocument>(
   document: T,

--- a/src/4.0/obfuscate.ts
+++ b/src/4.0/obfuscate.ts
@@ -71,7 +71,11 @@ export type ObfuscateVerifiableCredentialResult<T extends V4WrappedDocument> = O
   {
     credentialSubject: Override<
       PartialDeep<T["credentialSubject"]>,
-      { attachments?: V4WrappedDocument["credentialSubject"]["attachments"] }
+      {
+        attachments?: T["credentialSubject"]["attachments"] extends Array<unknown>
+          ? T["credentialSubject"]["attachments"]
+          : undefined;
+      }
     >;
   }
 >;


### PR DESCRIPTION
obfuscated return type should still be v4 document compliant