### PR TITLE
refactor: mark v3 functions as deprecated

### DIFF
--- a/src/3.0/digest.ts
+++ b/src/3.0/digest.ts
@@ -3,6 +3,9 @@ import { keccak256 } from "js-sha3";
 import { Salt } from "./types";
 import { OpenAttestationDocument } from "../__generated__/schema.3.0";
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const digestCredential = (document: OpenAttestationDocument, salts: Salt[], obfuscatedData: string[]) => {
   // Prepare array of hashes from visible data
   const hashedUnhashedDataArray = salts

--- a/src/3.0/obfuscate.ts
+++ b/src/3.0/obfuscate.ts
@@ -37,6 +37,9 @@ const obfuscate = (_data: WrappedDocument<OpenAttestationDocument>, fields: stri
   };
 };
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const obfuscateVerifiableCredential = (
   document: WrappedDocument<OpenAttestationDocument>,
   fields: string[] | string

--- a/src/3.0/salt.ts
+++ b/src/3.0/salt.ts
@@ -21,15 +21,28 @@ const illegalCharactersCheck = (data: Record<string, any>) => {
 
 // Using 32 bytes of entropy as compared to 16 bytes in uuid
 // Using hex encoding as compared to base64 for constant string length
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const secureRandomString = () => randomBytes(ENTROPY_IN_BYTES).toString("hex");
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const salt = (data: any): Salt[] => {
   // Check for illegal characters e.g. '.', '[' or ']'
   illegalCharactersCheck(data);
   return traverseAndFlatten(data, { iteratee: ({ path }) => ({ value: secureRandomString(), path }) });
 };
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const encodeSalt = (salts: Salt[]): string => Base64.encode(JSON.stringify(salts));
+
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const decodeSalt = (salts: string): Salt[] => {
   const decoded: Salt[] = JSON.parse(Base64.decode(salts));
   decoded.forEach((salt) => {

--- a/src/3.0/sign.ts
+++ b/src/3.0/sign.ts
@@ -9,6 +9,9 @@ import { SigningKey, SUPPORTED_SIGNING_ALGORITHM } from "../shared/@types/sign";
 import { isSignedWrappedV3Document } from "../shared/utils";
 import { ethers } from "ethers";
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const signDocument = async <T extends OpenAttestationDocument>(
   document: SignedWrappedDocument<T> | WrappedDocument<T>,
   algorithm: SUPPORTED_SIGNING_ALGORITHM,

--- a/src/3.0/traverseAndFlatten.ts
+++ b/src/3.0/traverseAndFlatten.ts
@@ -7,6 +7,9 @@ interface Options<T> {
   path?: string;
 }
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export function traverseAndFlatten<T>(data: any[], options: Options<T>): T[];
 export function traverseAndFlatten<T>(data: string | number | boolean | null, options: Options<T>): T;
 export function traverseAndFlatten<T>(data: any, options: Options<T>): T[]; // hmmmm this is probably wrong but it works for the moment :)

--- a/src/3.0/types.ts
+++ b/src/3.0/types.ts
@@ -3,15 +3,27 @@ import { OpenAttestationDocument as OpenAttestationDocumentV3 } from "../__gener
 import { OpenAttestationHexString, ProofPurpose, SchemaId, SignatureAlgorithm } from "../shared/@types/document";
 import { Array as RunTypesArray, Record as RunTypesRecord, Static, String } from "runtypes";
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export interface Salt {
   value: string;
   path: string;
 }
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const ObfuscationMetadata = RunTypesRecord({
   obfuscated: RunTypesArray(OpenAttestationHexString),
 });
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export type ObfuscationMetadata = Static<typeof ObfuscationMetadata>;
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const VerifiableCredentialWrappedProof = RunTypesRecord({
   type: SignatureAlgorithm,
   targetHash: String,
@@ -21,7 +33,13 @@ export const VerifiableCredentialWrappedProof = RunTypesRecord({
   privacy: ObfuscationMetadata,
   proofPurpose: ProofPurpose,
 });
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export type VerifiableCredentialWrappedProof = Static<typeof VerifiableCredentialWrappedProof>;
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const VerifiableCredentialWrappedProofStrict = VerifiableCredentialWrappedProof.And(
   RunTypesRecord({
     targetHash: OpenAttestationHexString,
@@ -29,27 +47,45 @@ export const VerifiableCredentialWrappedProofStrict = VerifiableCredentialWrappe
     proofs: RunTypesArray(OpenAttestationHexString),
   })
 );
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export type VerifiableCredentialWrappedProofStrict = Static<typeof VerifiableCredentialWrappedProofStrict>;
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const VerifiableCredentialSignedProof = VerifiableCredentialWrappedProof.And(
   RunTypesRecord({
     key: String,
     signature: String,
   })
 );
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export type VerifiableCredentialSignedProof = Static<typeof VerifiableCredentialSignedProof>;
 
 // TODO rename to something else that is not proof to allow for did-signed documents
 // Also it makes sense to use `proof` to denote a document that has been issued
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export type WrappedDocument<T extends OpenAttestationDocumentV3 = OpenAttestationDocumentV3> = T & {
   version: SchemaId.v3;
   schema?: string;
   proof: VerifiableCredentialWrappedProof;
 };
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export type SignedWrappedDocument<T extends OpenAttestationDocumentV3 = OpenAttestationDocumentV3> =
   WrappedDocument<T> & {
     proof: VerifiableCredentialSignedProof;
   };
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export * from "../__generated__/schema.3.0";

--- a/src/3.0/verify.ts
+++ b/src/3.0/verify.ts
@@ -3,6 +3,9 @@ import { digestCredential } from "./digest";
 import { checkProof } from "../shared/merkle";
 import { decodeSalt, salt } from "./salt";
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const verify = <T extends WrappedDocument>(document: T): document is WrappedDocument<T> => {
   if (!document.proof) {
     return false;

--- a/src/3.0/wrap.ts
+++ b/src/3.0/wrap.ts
@@ -12,6 +12,9 @@ import { getSchema } from "../shared/ajv";
 
 const getExternalSchema = (schema?: string) => (schema ? { schema } : {});
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const wrapDocument = async <T extends OpenAttestationDocument>(
   credential: T,
   options: WrapDocumentOptionV3
@@ -67,6 +70,9 @@ export const wrapDocument = async <T extends OpenAttestationDocument>(
   return verifiableCredential;
 };
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const wrapDocuments = async <T extends OpenAttestationDocument>(
   documents: T[],
   options: WrapDocumentOptionV3

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,9 @@ import { SigningKey, SUPPORTED_SIGNING_ALGORITHM } from "./shared/@types/sign";
 import { ethers, Signer } from "ethers";
 import { getSchema } from "./shared/ajv";
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export function __unsafe__use__it__at__your__own__risks__wrapDocument<T extends OpenAttestationDocumentV3>(
   data: T,
   options?: WrapDocumentOptionV3
@@ -28,6 +31,9 @@ export function __unsafe__use__it__at__your__own__risks__wrapDocument<T extends 
   return wrapV3Document(data, options ?? { version: SchemaId.v3 });
 }
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export function __unsafe__use__it__at__your__own__risks__wrapDocuments<T extends OpenAttestationDocumentV3>(
   dataArray: T[],
   options?: WrapDocumentOptionV3

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,9 @@ export const isSchemaValidationError = (error: any): error is SchemaValidationEr
   return !!error.validationErrors;
 };
 
+/**
+ * @deprecated signing of v3 documents will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export async function signDocument<T extends v3.OpenAttestationDocument>(
   document: v3.SignedWrappedDocument<T> | v3.WrappedDocument<T>,
   algorithm: SUPPORTED_SIGNING_ALGORITHM,

--- a/src/shared/@types/wrap.ts
+++ b/src/shared/@types/wrap.ts
@@ -4,15 +4,23 @@ export interface WrapDocumentOption {
   externalSchemaId?: string;
   version?: SchemaId;
 }
+
 export interface WrapDocumentOptionV2 {
   externalSchemaId?: string;
   version?: SchemaId.v2;
 }
+
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export interface WrapDocumentOptionV3 {
   externalSchemaId?: string;
   version: SchemaId.v3;
 }
 
+/**
+ * @deprecated will be removed in the next major release in favour of OpenAttestation v4.0 (more info: https://github.com/Open-Attestation/open-attestation/tree/alpha)
+ */
 export const isWrapDocumentOptionV3 = (options: any): options is WrapDocumentOptionV3 => {
   return options?.version === SchemaId.v3;
 };


### PR DESCRIPTION
Mark v3 functions as deprecated in favour of the upcoming OpenAttestation v4.0 release