### PR TITLE
feat: unknown document parser

### DIFF
--- a/src/2.0/parseUnknownDocument.ts
+++ b/src/2.0/parseUnknownDocument.ts
@@ -1,0 +1,62 @@
+import { OpenAttestationDocument, WrappedDocument, SignedWrappedDocument } from "./types";
+import { isRawV2Document, isSignedWrappedV2Document, isWrappedV2Document } from "../shared/utils/guard";
+import { SchemaId } from "../shared/@types/document";
+import { PartialDeep } from "../4.0/types";
+
+type V2ParsedDocument =
+  | {
+      version: "2.0";
+      type: "raw";
+      document: OpenAttestationDocument;
+    }
+  | {
+      version: "2.0";
+      type: "wrapped";
+      document: WrappedDocument;
+    }
+  | {
+      version: "2.0";
+      type: "signedWrapped";
+      document: SignedWrappedDocument;
+    };
+
+const isPotentialV2 = (document: unknown): document is PartialDeep<SignedWrappedDocument> => {
+  return (document as SignedWrappedDocument)?.version === SchemaId.v2;
+};
+const isPotentialV2OpenAttestationDocument = (document: unknown): document is PartialDeep<OpenAttestationDocument> => {
+  return (document as OpenAttestationDocument).$template !== undefined;
+};
+export function v2ParseUnknownDocument(document: unknown): V2ParsedDocument | null {
+  if (isPotentialV2(document)) {
+    if (document.proof) {
+      if (isSignedWrappedV2Document(document)) {
+        return {
+          version: "2.0",
+          type: "signedWrapped",
+          document,
+        };
+      }
+      return null;
+    }
+    if (isWrappedV2Document(document)) {
+      return {
+        version: "2.0",
+        type: "wrapped",
+        document,
+      };
+    }
+    return null;
+  }
+
+  if (isPotentialV2OpenAttestationDocument(document)) {
+    if (isRawV2Document(document)) {
+      return {
+        version: "2.0",
+        type: "raw",
+        document,
+      };
+    }
+  }
+
+  return null;
+}

--- a/src/2.0/parseUnknownDocument.ts
+++ b/src/2.0/parseUnknownDocument.ts
@@ -26,7 +26,7 @@ const isPotentialV2 = (document: unknown): document is PartialDeep<SignedWrapped
 const isPotentialV2OpenAttestationDocument = (document: unknown): document is PartialDeep<OpenAttestationDocument> => {
   return (document as OpenAttestationDocument).$template !== undefined;
 };
-export function v2ParseUnknownDocument(document: unknown): V2ParsedDocument | null {
+export function v2ParseUnknownDocument(document: unknown): V2ParsedDocument | "invalid" | undefined {
   if (isPotentialV2(document)) {
     if (document.proof) {
       if (isSignedWrappedV2Document(document)) {
@@ -36,7 +36,7 @@ export function v2ParseUnknownDocument(document: unknown): V2ParsedDocument | nu
           document,
         };
       }
-      return null;
+      return "invalid";
     }
     if (isWrappedV2Document(document)) {
       return {
@@ -45,7 +45,7 @@ export function v2ParseUnknownDocument(document: unknown): V2ParsedDocument | nu
         document,
       };
     }
-    return null;
+    return "invalid";
   }
 
   if (isPotentialV2OpenAttestationDocument(document)) {
@@ -57,6 +57,4 @@ export function v2ParseUnknownDocument(document: unknown): V2ParsedDocument | nu
       };
     }
   }
-
-  return null;
 }

--- a/src/4.0/parseUnknownDocument.ts
+++ b/src/4.0/parseUnknownDocument.ts
@@ -1,0 +1,64 @@
+import {
+  PartialDeep,
+  V4OpenAttestationDocument,
+  V4SignedWrappedDocument,
+  V4WrappedDocument,
+  isV4OpenAttestationDocument,
+  isV4SignedWrappedDocument,
+  isV4WrappedDocument,
+} from "./types";
+
+type V4ParsedDocument =
+  | {
+      version: "4.0";
+      type: "raw";
+      document: V4OpenAttestationDocument;
+    }
+  | {
+      version: "4.0";
+      type: "wrapped";
+      document: V4WrappedDocument;
+    }
+  | {
+      version: "4.0";
+      type: "signedWrapped";
+      document: V4SignedWrappedDocument;
+    };
+const isPotentialV4 = (document: unknown): document is PartialDeep<V4SignedWrappedDocument> => {
+  return V4OpenAttestationDocument.pick({ "@context": true }).passthrough().safeParse(document).success;
+};
+export function v4ParseUnknownDocument(document: unknown): V4ParsedDocument | null {
+  if (isPotentialV4(document)) {
+    if (document.proof) {
+      // only wrapped/signedWrapped document has proof
+      if (document.proof.signature) {
+        // only signedWrapped document has signature
+        if (isV4SignedWrappedDocument(document)) {
+          return {
+            version: "4.0",
+            type: "signedWrapped",
+            document,
+          };
+        }
+        return null;
+      }
+      if (isV4WrappedDocument(document)) {
+        return {
+          version: "4.0",
+          type: "wrapped",
+          document,
+        };
+      }
+      return null;
+    }
+    if (isV4OpenAttestationDocument(document)) {
+      return {
+        version: "4.0",
+        type: "raw",
+        document,
+      };
+    }
+    return null;
+  }
+  return null;
+}

--- a/src/4.0/parseUnknownDocument.ts
+++ b/src/4.0/parseUnknownDocument.ts
@@ -27,7 +27,7 @@ type V4ParsedDocument =
 const isPotentialV4 = (document: unknown): document is PartialDeep<V4SignedWrappedDocument> => {
   return V4OpenAttestationDocument.pick({ "@context": true }).passthrough().safeParse(document).success;
 };
-export function v4ParseUnknownDocument(document: unknown): V4ParsedDocument | null {
+export function v4ParseUnknownDocument(document: unknown): V4ParsedDocument | "invalid" | undefined {
   if (isPotentialV4(document)) {
     if (document.proof) {
       // only wrapped/signedWrapped document has proof
@@ -40,7 +40,7 @@ export function v4ParseUnknownDocument(document: unknown): V4ParsedDocument | nu
             document,
           };
         }
-        return null;
+        return "invalid";
       }
       if (isV4WrappedDocument(document)) {
         return {
@@ -49,7 +49,7 @@ export function v4ParseUnknownDocument(document: unknown): V4ParsedDocument | nu
           document,
         };
       }
-      return null;
+      return "invalid";
     }
     if (isV4OpenAttestationDocument(document)) {
       return {
@@ -58,7 +58,6 @@ export function v4ParseUnknownDocument(document: unknown): V4ParsedDocument | nu
         document,
       };
     }
-    return null;
+    return "invalid";
   }
-  return null;
 }

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -3,3 +3,4 @@ export * from "./guard";
 export * from "./diagnose";
 export * from "../../2.0/utils";
 export * from "./hashing";
+export * from "./parseUnknownDocument";

--- a/src/shared/utils/parseUnknownDocument.ts
+++ b/src/shared/utils/parseUnknownDocument.ts
@@ -1,0 +1,13 @@
+import { v2ParseUnknownDocument } from "../../2.0/parseUnknownDocument";
+import { v4ParseUnknownDocument } from "../../4.0/parseUnknownDocument";
+
+const PARSERS = [v2ParseUnknownDocument, v4ParseUnknownDocument] as const satisfies ReadonlyArray<
+  (document: unknown) => { version: string; type: string; document: unknown } | null
+>;
+export function parseUnknownDocument(document: unknown) {
+  for (const parser of PARSERS) {
+    const results = parser(document);
+    if (results) return results;
+  }
+  throw new Error("Cannot determine version of document");
+}

--- a/src/shared/utils/parseUnknownDocument.ts
+++ b/src/shared/utils/parseUnknownDocument.ts
@@ -2,12 +2,19 @@ import { v2ParseUnknownDocument } from "../../2.0/parseUnknownDocument";
 import { v4ParseUnknownDocument } from "../../4.0/parseUnknownDocument";
 
 const PARSERS = [v2ParseUnknownDocument, v4ParseUnknownDocument] as const satisfies ReadonlyArray<
-  (document: unknown) => { version: string; type: string; document: unknown } | null
+  (document: unknown) => { version: string; type: string; document: unknown } | "invalid" | undefined
 >;
 export function parseUnknownDocument(document: unknown) {
   for (const parser of PARSERS) {
     const results = parser(document);
-    if (results) return results;
+    if (results === "invalid") {
+      throw new Error("Cannot determine version of document");
+    }
+
+    if (results) {
+      return results;
+    }
   }
+
   throw new Error("Cannot determine version of document");
 }


### PR DESCRIPTION
quickly determine what document we are dealing with

## usage example
```typescript
export const getTemplateUrl = (_document: unknown): string | undefined => {
  const { version, type, document } = parseUnknownDocument(_document);
  if (version === "2.0") {
    const unwrappedDocument = type === "raw" ? document : getData(document);
    if (typeof unwrappedDocument.$template === "string") return unwrappedDocument.$template;
    else return unwrappedDocument.$template?.url;
  }

  if (version === "4.0") {
    return document.renderMethod && document.renderMethod[0].id;
  }

  throw new Error(
    "Unsupported document type: Only can retrieve template url from OpenAttestation v2 and v4 documents."
  );
};
```