### PR TITLE
fix: obfuscation of an array element can lead to undefined error

### DIFF
--- a/src/4.0/obfuscate.ts
+++ b/src/4.0/obfuscate.ts
@@ -10,7 +10,14 @@ const obfuscate = (_data: V4WrappedDocument, fields: string[] | string) => {
 
   // fields to remove will contain the list of each expanded keys from the fields passed in parameter, it's for instance useful in case of
   // object obfuscation, where the object itself is not part of the salts, but each individual keys are
-  const toBeRemovedLeafNodes = traverseAndFlatten(pick(data, fieldsAsArray), ({ path }) => path);
+  const toBeRemovedLeafNodes = traverseAndFlatten(
+    pick(data, fieldsAsArray),
+    ({ path }) => path,
+    "",
+    // not picking from an array can lead to unpicked items being left as undefined
+    // these 'undefined' leaf nodes should be removed and not lead to an exception
+    true
+  );
   const salts = decodeSalt(data.proof.salts);
 
   const obfuscatedData = toBeRemovedLeafNodes.map((field) => {

--- a/src/4.0/traverseAndFlatten.ts
+++ b/src/4.0/traverseAndFlatten.ts
@@ -1,9 +1,13 @@
 export type LeafValue = string | number | boolean | null | Record<string, never> | [];
 
+// we use a symbol just in case of conflicts with what the iteratee returns
+const undefinedSym = Symbol("undefined value that should be filtered away");
+
 function _traverseAndFlatten<IterateeValue>(
   data: unknown,
   iteratee: (data: { value: LeafValue; path: string }) => IterateeValue,
-  path = ""
+  path = "",
+  isRemoveUndefinedLeafNodes = false
 ): IterateeValue | IterateeValue[] {
   if (Array.isArray(data)) {
     // an empty array is considered a leaf node
@@ -13,7 +17,7 @@ function _traverseAndFlatten<IterateeValue>(
     const results: IterateeValue[] = [];
     for (let index = 0; index < data.length; index++) {
       const value = data[index];
-      const result = _traverseAndFlatten(value, iteratee, `${path}[${index}]`);
+      const result = _traverseAndFlatten(value, iteratee, `${path}[${index}]`, isRemoveUndefinedLeafNodes);
       if (Array.isArray(result)) {
         results.push(...result);
       } else {
@@ -29,12 +33,22 @@ function _traverseAndFlatten<IterateeValue>(
     // an empty object is considered a leaf node
     if (keys.length === 0) return iteratee({ value: {}, path });
     return Object.keys(data).flatMap((key) =>
-      _traverseAndFlatten(data[key as keyof typeof data], iteratee, path ? `${path}.${key}` : key)
+      _traverseAndFlatten(
+        data[key as keyof typeof data],
+        iteratee,
+        path ? `${path}.${key}` : key,
+        isRemoveUndefinedLeafNodes
+      )
     );
   }
 
   if (typeof data === "string" || typeof data === "number" || typeof data === "boolean" || data === null) {
     return iteratee({ value: data, path });
+  }
+
+  if (data === undefined && isRemoveUndefinedLeafNodes) {
+    // mark undefined leaf node with a unique symbol that must be removed later
+    return undefinedSym as IterateeValue;
   }
 
   throw new Error(`Unexpected data '${data}' in '${path}'`);
@@ -44,8 +58,11 @@ function _traverseAndFlatten<IterateeValue>(
 export function traverseAndFlatten<IterateeValue>(
   data: Record<string, unknown>,
   iteratee: (data: { value: LeafValue; path: string }) => IterateeValue,
-  path = ""
+  path = "",
+  /** by default throw when there are leaf nodes that are undefined, setting this to true will remove them instead */
+  isRemoveUndefinedLeafNodes = false
 ): IterateeValue[] {
-  const results = _traverseAndFlatten(data, iteratee, path);
-  return Array.isArray(results) ? results : [];
+  const results = _traverseAndFlatten(data, iteratee, path, isRemoveUndefinedLeafNodes);
+  // remove undefined leaf nodes
+  return Array.isArray(results) ? results.filter((v) => v !== undefinedSym) : [];
 }


### PR DESCRIPTION
## why
In normal circumstances, we should expect that there will be no leaf node in a document that will be `undefined`, since in JSON land, which is the type that we will always serialise, does not have such a primitive. This is the reason why we only handle known JSON primitive types in `traverseAndFlatten`, and throw otherwise.

The problem comes during `obfuscation`, when `traverseAndFlatten` is used to flatten leaf nodes that are to be removed. We do so by using lodash's `pick` on our document, that in cases where there are arrays involved, array items that are not picked, will be left as an `undefined/<empty item>`.

`pick([1,2,3,4], 3)` will result in `[undefined, undefined, undefined, 4]` which is passed to `traverseAndFlatten` which then throws because now it encounters an unexpected type.

## what
Added a flag on `traverseAndFlatten` to remove `undefined` values instead of throwing, it defaults to `false`

