### PR TITLE
feat: allow any credentialStatus for oa v4

### DIFF
--- a/src/4.0/jsonSchemas/__generated__/v4-document.schema.json
+++ b/src/4.0/jsonSchemas/__generated__/v4-document.schema.json
@@ -216,6 +216,18 @@
                 "type"
               ],
               "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": true
             }
           ]
         },

--- a/src/4.0/jsonSchemas/__generated__/v4-signed-wrapped-document.schema.json
+++ b/src/4.0/jsonSchemas/__generated__/v4-signed-wrapped-document.schema.json
@@ -216,6 +216,18 @@
                 "type"
               ],
               "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": true
             }
           ]
         },

--- a/src/4.0/jsonSchemas/__generated__/v4-wrapped-document.schema.json
+++ b/src/4.0/jsonSchemas/__generated__/v4-wrapped-document.schema.json
@@ -216,6 +216,18 @@
                 "type"
               ],
               "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": true
             }
           ]
         },

--- a/src/4.0/types.ts
+++ b/src/4.0/types.ts
@@ -234,7 +234,9 @@ export const V4OpenAttestationDocument = _W3cVerifiableCredential
       }),
 
     // [Optional] Credential Status
-    credentialStatus: z.discriminatedUnion("type", [OscpResponderRevocation, RevocationStoreRevocation]).optional(),
+    credentialStatus: z
+      .union([OscpResponderRevocation, RevocationStoreRevocation, z.object({ type: z.string() }).passthrough()])
+      .optional(),
 
     // [Optional] Render Method
     renderMethod: z.array(z.discriminatedUnion("type", [DecentralisedEmbeddedRenderer, SvgRenderer])).optional(),


### PR DESCRIPTION
## Summary

What is the background of this pull request?
- To remove restriction for credetialStatus v4

## Changes

What are the changes made in this pull request?
- Allowing any type for credentialStatus in oa v4.

## Issues

What are the related issues or stories?
- TradeTrust will be utilising oa v4. However we will require customisation to allow other type value for credentialStatus.
- Note: No @context schema validation in place for external type.

Happy to have a discussion for any suggestion. 