### PR TITLE
fix: allow digesting and signing of modified oa vcs

### DIFF
--- a/src/4.0/__tests__/digest.test.ts
+++ b/src/4.0/__tests__/digest.test.ts
@@ -3,6 +3,7 @@ import {
   ProoflessOAVerifiableCredential,
   OADigestedOAVerifiableCredential,
   W3cVerifiableCredential,
+  ProoflessW3cVerifiableCredential,
 } from "../types";
 import { digestVc } from "../digest";
 
@@ -110,7 +111,7 @@ describe("V4.0 digest", () => {
     `);
   });
 
-  test("given a generic W3C VC, should digest with context and type corrected", async () => {
+  test("given a generic W3C VC and with validate with OA data model disabled, should digest with context and type corrected", async () => {
     const genericW3cVc: W3cVerifiableCredential = {
       "@context": ["https://www.w3.org/ns/credentials/v2"],
       type: ["VerifiableCredential"],
@@ -123,7 +124,7 @@ describe("V4.0 digest", () => {
         id: "https://example.com/issuer/123",
       },
     };
-    const digested = await digestVc(genericW3cVc as unknown as ProoflessOAVerifiableCredential);
+    const digested = await digestVc(genericW3cVc as unknown as ProoflessW3cVerifiableCredential, true);
     const parsedResults = OADigestedOAVerifiableCredential.pick({ "@context": true, type: true })
       .passthrough()
       .safeParse(digested);

--- a/src/4.0/__tests__/e2e.test.ts
+++ b/src/4.0/__tests__/e2e.test.ts
@@ -119,31 +119,28 @@ describe("V4.0 E2E Test Scenarios", () => {
           } as unknown as ProoflessOAVerifiableCredential,
         ];
         await expect(digestVcs(malformedDatum)).rejects.toThrowErrorMatchingInlineSnapshot(`
-          "Input VC does not conform to Verifiable Credentials v2.0 Data Model: 
+          "Input VC does not conform to Open Attestation v4.0 Data Model: 
            {
-            "_errors": [],
+            "_errors": [
+              "Unrecognized key(s) in object: 'laurent'"
+            ],
             "@context": {
               "_errors": [
-                "Required",
-                "Required",
-                "Required"
-              ]
-            },
-            "issuer": {
-              "_errors": [
-                "Required",
                 "Required"
               ]
             },
             "type": {
               "_errors": [
-                "Required",
+                "Required"
+              ]
+            },
+            "issuer": {
+              "_errors": [
                 "Required"
               ]
             },
             "credentialSubject": {
               "_errors": [
-                "Required",
                 "Required"
               ]
             }

--- a/src/4.0/sign.ts
+++ b/src/4.0/sign.ts
@@ -5,13 +5,25 @@ import { SigningKey } from "../shared/@types/sign";
 import { digestVc, digestVcErrors } from "./digest";
 import type { ProoflessOAVerifiableCredential, ProoflessW3cVerifiableCredential, OASigned } from "./types";
 
-export const signVc = async <T extends ProoflessW3cVerifiableCredential = ProoflessOAVerifiableCredential>(
+export async function signVc<T extends ProoflessOAVerifiableCredential>(
   unsignedVc: T,
   algorithm: "Secp256k1VerificationKey2018",
   keyOrSigner: SigningKey | Signer
-): Promise<OASigned<T>> => {
+): Promise<OASigned<T>>;
+export async function signVc<T extends ProoflessW3cVerifiableCredential>(
+  unsignedVc: T,
+  algorithm: "Secp256k1VerificationKey2018",
+  keyOrSigner: SigningKey | Signer,
+  isUseW3cDataModel: boolean
+): Promise<OASigned<T>>;
+export async function signVc<T extends ProoflessW3cVerifiableCredential>(
+  unsignedVc: T,
+  algorithm: "Secp256k1VerificationKey2018",
+  keyOrSigner: SigningKey | Signer,
+  isUseW3cDataModel?: boolean
+): Promise<OASigned<T>> {
   /* 1. Input VC needs to be digested first */
-  const digestedVc = await digestVc(unsignedVc);
+  const digestedVc = await digestVc(unsignedVc, isUseW3cDataModel ?? false);
   const validatedProof = digestedVc.proof;
 
   const merkleRoot = `0x${validatedProof.merkleRoot}`;
@@ -33,7 +45,7 @@ export const signVc = async <T extends ProoflessW3cVerifiableCredential = Proofl
   } catch (error) {
     throw new CouldNotSignVcError(error);
   }
-};
+}
 
 /**
  * Cases where this can be thrown includes: network error, invalid keys or signer


### PR DESCRIPTION
## Why

We can no longer infer users intention to validate against OA vc data model or the generic w3c VC data model

